### PR TITLE
Fixes #496

### DIFF
--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -136,6 +136,13 @@ function extractPackageInfo (plugin, pkgMeta, schema) {
   // set the type and package id for the package
   info[plugin.packageType] = pkgMeta[plugin.packageType];
 
+  // set extra properties
+  plugin.extra && plugin.extra.forEach(function (key) {
+    if (pkgMeta[key]) {
+      info[key] = pkgMeta[key];
+    }
+  });
+
   return info;
 }
 

--- a/plugins/content/extension/extensiontype.schema
+++ b/plugins/content/extension/extensiontype.schema
@@ -8,6 +8,11 @@
       "type": "string",
       "required": true
     },
+    "targetAttribute": {
+      "type": "string",
+      "required": true,
+      "default": "undefined"
+    },
     "properties":{
       "type": "object"
     }

--- a/plugins/content/extension/index.js
+++ b/plugins/content/extension/index.js
@@ -28,6 +28,7 @@ var bowerConfig = {
   keywords: 'adapt-extension',
   packageType: 'extension',
   options: defaultOptions,
+  extra: [ "targetAttribute" ],
   nameList: [
     "adapt-contrib-assessment#develop",
     "adapt-contrib-pageLevelProgress#develop",


### PR DESCRIPTION
this fixes an issue where targetAttribute was not getting set in the extension properties as read from bower.json. This fix also allows any bower plugin to pluck arbitrary properties out of the bower.json and save that property in the plugin document.
