### PR TITLE
Fixes #515

### DIFF
--- a/frontend/src/core/editor/editor.js
+++ b/frontend/src/core/editor/editor.js
@@ -50,6 +50,8 @@ define(function(require) {
   var dataIsLoaded = false;
 
   Origin.on('editor:refreshData', function(callback, context) {
+    Origin.editor.data.config.attributes._enabledExtensions = null;
+    
     dataIsLoaded = false;
     var loadedData = {
       clipboard: false,

--- a/frontend/src/core/editor/editor.js
+++ b/frontend/src/core/editor/editor.js
@@ -50,8 +50,6 @@ define(function(require) {
   var dataIsLoaded = false;
 
   Origin.on('editor:refreshData', function(callback, context) {
-    Origin.editor.data.config.attributes._enabledExtensions = null;
-    
     dataIsLoaded = false;
     var loadedData = {
       clipboard: false,

--- a/frontend/src/core/editor/extensions/views/editorExtensionsEditView.js
+++ b/frontend/src/core/editor/extensions/views/editorExtensionsEditView.js
@@ -118,6 +118,7 @@ define(function(require) {
     },
 
     removeExtension: function() {
+        var numCurrentExtensions = this.model.attributes.enabledExtensions.length;
         $.post('/api/extension/disable/' + this.model.get('_id'), {
                 extensions: this.currentSelectedIds 
             }, _.bind(function(result) {
@@ -125,6 +126,11 @@ define(function(require) {
 
                 Origin.trigger('editor:refreshData', function() {
                     this.setupExtensions();
+
+                    if (numCurrentExtensions === 1) {
+                        this.model.set("enabledExtensions", null);
+                        this.render();
+                    }
                 }, this);
 
             } else {
@@ -141,3 +147,5 @@ define(function(require) {
   return EditorExtensionsEditView;
 
 });
+
+    


### PR DESCRIPTION
When removing the last extension on a course, the _enabledExtensions attribute was deleted. This caused it to be ignored when refreshing the data, instead of updating it to be empty. This fix sets the attribute to be null before the refresh happens, so that the attribute exists and will cause the extensions to update.