### PR TITLE
Improve plugin upload process backend

### DIFF
--- a/frontend/src/core/pluginManagement/views/pluginManagementUploadView.js
+++ b/frontend/src/core/pluginManagement/views/pluginManagementUploadView.js
@@ -29,11 +29,15 @@ define(function(require){
         error: function(data, status, error) {
           $('.loading').hide();
           var message = 'There was an error uploading the plugin';
+
           if (data && data.responseJSON && data.responseJSON.error) {
             message += ":\n\n" + data.responseJSON.error;
           }
 
           alert(message);
+
+          // go back to the upload, maybe handle this in the sidebar?
+          Origin.router.navigate('#/pluginManagement/upload', { trigger: true });
         },
         success: function(data, status, xhr) {
           Origin.trigger('scaffold:updateSchemas', function() {

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "semver": "^2.3.1",
     "socket.io": "^1.1.0",
     "underscore": "~1.5.2",
-    "unzip": "0.1.8",
     "validator": "3.3.0",
-    "winston": "0.7.2"
+    "winston": "0.7.2",
+    "unzip2": "^0.2.5"
   },
   "main": "index",
   "engines": {

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -797,7 +797,17 @@ function handleUploadedPlugin (req, res, next) {
 
         // first entry should be our target directory
         var packageJson;
-        var canonicalDir = path.join(outputPath, files[0]);
+        var canonicalDir;
+
+        if(files.indexOf("bower.json") != -1) {
+          console.log("At root level");
+          canonicalDir = outputPath
+        }
+        else {
+          var e = new Error("Cannot find bower.json file in the plugin root, please check your zip file and try again.");
+          return next(e);
+        }
+
         try {
           packageJson = require(path.join(canonicalDir, 'bower.json'));
         } catch (error) {

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -790,7 +790,9 @@ function handleUploadedPlugin (req, res, next) {
     .on('close', function (data) {
       // enumerate output directory and search for bower.json
       fs.readdir(outputPath, function (err, files) {
-        if (err) return next(err);
+        if (err) {
+          return next(err);
+        }
 
         // first entry should be our target directory
         var packageJson;
@@ -798,14 +800,17 @@ function handleUploadedPlugin (req, res, next) {
 
         if(files.indexOf("bower.json") != -1) {
           canonicalDir = outputPath
-        }
-        else {
+        } else {
           var e = new Error("Cannot find bower.json file in the plugin root, please check your zip file and try again.");
           return next(e);
         }
 
-        try { packageJson = require(path.join(canonicalDir, 'bower.json')); }
-        catch (error) { return next(error); }
+        try {
+          packageJson = require(path.join(canonicalDir, 'bower.json'));
+        }
+        catch (error) {
+          return next(error);
+        }
 
         // extract the plugin type from the package
         var pluginType = extractPluginType(packageJson);

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -794,7 +794,6 @@ function handleUploadedPlugin (req, res, next) {
           return next(err);
         }
 
-        // first entry should be our target directory
         var packageJson;
         var canonicalDir;
 

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -800,7 +800,6 @@ function handleUploadedPlugin (req, res, next) {
         var canonicalDir;
 
         if(files.indexOf("bower.json") != -1) {
-          console.log("At root level");
           canonicalDir = outputPath
         }
         else {


### PR DESCRIPTION
Switched to unzip2 to allow for __MACOSX folders (which are added if using the mac's built-in archive option in the right-click menu) - this folder could be removed during the unzip process, but I think we should take care of this, rather than expecting the user to do it

Added a more helpful error message for case where bower.json isn't in expected place

Changed the code to expect the folder to have been zipped from the inside, rather than to include a nested level, as this is what I've come to expect from similar systems.