### PR TITLE
Fixes potential issue with copying course

### DIFF
--- a/plugins/content/course/index.js
+++ b/plugins/content/course/index.js
@@ -429,20 +429,25 @@ function duplicate (data, cb) {
                   async.eachSeries(items, function(item, next) {
                     // For each course asset, before inserting the new document
                     // the _courseId and _contentTypeParentId must be changed
-                    var courseAsset = item.toObject();
-                    delete courseAsset._id;
+                    if (parentIdMap[item._contentTypeParentId]) {
+                      var courseAsset = item.toObject();
+                      delete courseAsset._id;
 
-                    courseAsset._courseId = newCourseId;
-                    courseAsset._contentTypeParentId = parentIdMap[item._contentTypeParentId];
+                      courseAsset._courseId = newCourseId;
+                      courseAsset._contentTypeParentId = parentIdMap[item._contentTypeParentId];
 
-                    return db.create('courseasset', courseAsset, function (error, newCourseAsset) {
-                      if (error) {
-                        logger.log('error', error);
-                        return next(error);
-                      } else {
-                        next();
-                      }
-                    });
+                      return db.create('courseasset', courseAsset, function (error, newCourseAsset) {
+                        if (error) {
+                          logger.log('error', error);
+                          return next(error);
+                        } else {
+                          next();
+                        }
+                      });
+                    } else {
+                      next();
+                    }
+                    
                   }, function(error) {
                     if (error) {
                       logger.log('error', error);


### PR DESCRIPTION
There's now a fall through when the _contentTypeParentId doesn't exist in
the parentIdMap variable.  This could happen with courses created in an
earlier version of the builder.