### PR TITLE
issue/#635

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,12 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
       pkg: grunt.file.readJSON('package.json'),
+      "merge-json": {
+        en: {
+            src: ['routes/lang/en.json','frontend/src/plugins/**/lang/en.json'],
+            dest: 'routes/lang/en.json',
+        }
+      },
       copy: {
         main: {
           files: [
@@ -156,7 +162,7 @@ module.exports = function(grunt) {
         // Save the configuration
         grunt.file.write(configFile, JSON.stringify(config, null, 2));
 
-        grunt.task.run(['requirePlugins', 'copy', 'less', 'handlebars', 'requirejs:'+ compilation]);
+        grunt.task.run(['requirePlugins','merge-json', 'copy', 'less', 'handlebars', 'requirejs:'+ compilation]);
       } else {
         grunt.task.run(['requirePlugins', 'copy', 'less', 'handlebars', 'requirejs:dev']);
       }

--- a/package.json
+++ b/package.json
@@ -88,15 +88,16 @@
     "grunt-contrib-less": "~0.7.0",
     "grunt-contrib-requirejs": "~0.4.4",
     "grunt-contrib-watch": "~0.5.1",
+    "grunt-merge-json": "^0.9.5",
     "grunt-mocha-test": "~0.7.0",
     "grunt-open": "~0.2.2",
     "grunt-requirejs-bundle": "~0.0.7",
     "matchdep": "~0.3.0",
     "mocha": "~1.13.0",
     "node-ffprobe": "~1.2.2",
-    "should": "~1.3.0",
-    "supertest": "~0.8.1",
+    "node-polyglot": "~0.4.1",
     "nodemailer": "~1.3.0",
-    "node-polyglot": "~0.4.1"
+    "should": "~1.3.0",
+    "supertest": "~0.8.1"
   }
 }


### PR DESCRIPTION
desc: frontend plugins can have their own language files /lang/en.json currently only supported. Exisiting users will need to install grunt-merge-json: npm install grunt-merge-json --save-dev.