### PR TITLE
Fixes #620

### DIFF
--- a/install.js
+++ b/install.js
@@ -199,7 +199,15 @@ var steps = [
           return exitInstall(1, 'Framework install failed. See console output for possible reasons.');
         }
       
-        return next();
+        // Remove the default course
+        rimraf(path.resolve(__dirname, 'adapt_framework', 'src', 'course'), function(err) {
+          if (err) {
+            console.log('ERROR: ', err);
+            return exitInstall(1, 'Framework install error -- unable to remove default course.');
+          }
+
+          return next();
+        });
       });
      });
   },


### PR DESCRIPTION
This was due to the default framework course folder being copied over to
the temporary working/build directory.  The fix is to remove it on
installation.