### PR TITLE
Corrected caching of the single page app

### DIFF
--- a/routes/index/index.hbs
+++ b/routes/index/index.hbs
@@ -13,6 +13,9 @@
     <script type="text/javascript" src="core/app/config.js"></script>
     <script type="text/javascript" src="core/app/app.js"></script>
     {{/if}}
+    <meta http-equiv="cache-control" content="no-store, no-cache, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-store, no-cache" />
+    <meta http-equiv="Expires" content="0" />
   </head>
   <body>
     <div id="app" class="app container">


### PR DESCRIPTION
Explicitly setting the caching on the index page is required to ensure that the latest Javascript changes are picked up after a new build.