### PR TITLE
Fixes #863

### DIFF
--- a/frontend/src/core/assetManagement/views/assetManagementCollectionView.js
+++ b/frontend/src/core/assetManagement/views/assetManagementCollectionView.js
@@ -95,6 +95,7 @@ define(function(require){
               this.collection.reset();
             }
 
+            this.search = {_isDeleted: false};
             this.search = _.extend(this.search, {
                 tags: {
                     $in: this.tags

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -198,20 +198,6 @@ exports = module.exports = {
     } else {
       options.populate = _.extend(pop, options.populate);
     }
-
-    // Extend the search by _isDeleted to not return the soft deleted assets
-    // unless the api has a search of _isDeleted
-    if (options.search && options.search.hasOwnProperty("_isDeleted")) {
-      search = _.extend(search, {_isDeleted: options.search._isDeleted});
-    } else {
-      search = _.extend(search, {_isDeleted: false});
-    }
-    
-    // A preview/publish should not care if an asset has been flagged as deleted,
-    // so remove this from the filter criteria.
-    if (options.isPublish && search.hasOwnProperty('_isDeleted')) {
-      delete search._isDeleted;
-    }
     
     database.getDatabase(function (error, db) {
       if (error) {
@@ -613,6 +599,14 @@ exports = module.exports = {
     var orList = [];
     var andList = [];
 
+    if (search.hasOwnProperty('_isDeleted')) {
+      if (search._isDeleted == 'false') {
+        search._isDeleted = false;
+      } else {
+        search._isDeleted = true;
+      }
+    }
+    
     // convert searches to regex
     async.each(
       Object.keys(search),

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -207,6 +207,12 @@ exports = module.exports = {
       search = _.extend(search, {_isDeleted: false});
     }
     
+    // A preview/publish should not care if an asset has been flagged as deleted,
+    // so remove this from the filter criteria.
+    if (options.isPublish && search.hasOwnProperty('_isDeleted')) {
+      delete search._isDeleted;
+    }
+    
     database.getDatabase(function (error, db) {
       if (error) {
         return next(error);

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -473,7 +473,7 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
                             async.eachSeries(results, function(result, callback) {
 
                               // Retrieve the asset details
-                              assetmanager.retrieveAsset({ _id: result._assetId}, {isPublish: true}, function (error, assets) {
+                              assetmanager.retrieveAsset({ _id: result._assetId}, function (error, assets) {
                                 if (error) {
                                   return callback(error);
                                 } 
@@ -633,7 +633,7 @@ OutputPlugin.prototype.writeCourseAssets = function(tenantId, courseId, destinat
             async.eachSeries(results, function(result, callback) {
 
               // Retrieve the asset details
-              assetmanager.retrieveAsset({ _id: result._assetId }, {isPublish: true}, function (error, assets) {
+              assetmanager.retrieveAsset({ _id: result._assetId }, function (error, assets) {
                 if (error) {
                   return callback(error);
                 } 

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -473,7 +473,7 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
                             async.eachSeries(results, function(result, callback) {
 
                               // Retrieve the asset details
-                              assetmanager.retrieveAsset({ _id: result._assetId}, function (error, assets) {
+                              assetmanager.retrieveAsset({ _id: result._assetId}, {isPublish: true}, function (error, assets) {
                                 if (error) {
                                   return callback(error);
                                 } 
@@ -633,7 +633,7 @@ OutputPlugin.prototype.writeCourseAssets = function(tenantId, courseId, destinat
             async.eachSeries(results, function(result, callback) {
 
               // Retrieve the asset details
-              assetmanager.retrieveAsset({ _id: result._assetId }, function (error, assets) {
+              assetmanager.retrieveAsset({ _id: result._assetId }, {isPublish: true}, function (error, assets) {
                 if (error) {
                   return callback(error);
                 } 


### PR DESCRIPTION
The _isDeleted flag should be exluded from the filter criteria whenever a preview or publish is run, otherwise assets which were added to a course before they were deleted will cause errors.