### PR TITLE
Resolves #876 -- Adds support for MongoDB replicasets

### DIFF
--- a/lib/dml/mongoose/index.js
+++ b/lib/dml/mongoose/index.js
@@ -45,29 +45,43 @@ MongooseDB.prototype.connect = function(db) {
   var dbPass = false;
   var dbPort = false;
   var dbName = false;
-  var authPart = false;
-  var portPart = false;
+  var dbReplicaset = false;
+  var authenticationString = '';
+  var portString = '';
+  var options = {};
 
-  // using a tenant object
+  // Retrieve the tenant name.
   if ('object' === typeof db) {
-    dbHost = db.dbHost;
-    dbUser = db.dbUser;
-    dbPass = db.dbPass
-    dbPort = db.dbPort;
+    // We are using a tenant object.
     dbName = db.dbName;
-  } else { // using masterdb
-    dbHost = configuration.getConfig('dbHost');
-    dbUser = configuration.getConfig('dbUser');
-    dbPass = configuration.getConfig('dbPass');
-    dbPort = configuration.getConfig('dbPort');
+  } else { 
+    // We're on the master tenant.
     dbName = configuration.getConfig('dbName');
   }
+  
+  // Retrieve the user credentials and options.
+  dbUser = configuration.getConfig('dbUser');
+  dbPass = configuration.getConfig('dbPass');
+  dbReplicaset = configuration.getConfig('dbReplicaset');
+  options = configuration.getConfig('dbOptions') || {};
+  
+  // Construct the authentication part of the connection string.
+  authenticationString = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
+  
+  // Check if a MongoDB replicaset array has been specified.
+  if (dbReplicaset && Array.isArray(dbReplicaset) && dbReplicaset.length !== 0) {
+    // The replicaset should contain an array of hosts and ports   
+    this.conn = mongoose.createConnection('mongodb://' + authenticationString + dbReplicaset.join(',') + '/' + dbName, options);
+  } else {
+    // Get the host and port number from the configuration.
+    dbHost = configuration.getConfig('dbHost');  
+    dbPort = configuration.getConfig('dbPort'); 
 
-  // construct our parts
-  authPart = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
-  portPart = dbPort ? ':' + dbPort : '';
+    portString = dbPort ? ':' + dbPort : '';
 
-  this.conn = mongoose.createConnection('mongodb://' + authPart + dbHost + portPart + '/' + dbName);
+    this.conn = mongoose.createConnection('mongodb://' + authenticationString + dbHost + portString + '/' + dbName, options);
+  }
+ 
   this.conn.on('error', logger.log.bind(logger, 'error'));
   this.conn.once('error', function(){ logger.log('error', 'Database Connection failed, please check your database'); }); //added to give console notification of the problem
   this.updatedAt = new Date();

--- a/lib/tenantmanager.js
+++ b/lib/tenantmanager.js
@@ -310,7 +310,12 @@ exports = module.exports = {
           dbPort: configuration.getConfig('dbPort')
         };
       }
-
+    
+      // Verify that the database name is valid.
+      if (tenant.database.dbName.length > 64) {
+        return callback(new TenantCreateError('Database Name must be a maximum of 64 characters long'));
+      }
+      
       // verify the tenant name
       db.retrieve('tenant', { name: tenant.name }, function (error, results) {
         if (error) {


### PR DESCRIPTION
This is a requirement for high availability environments.  It can be implemented by adding a 'dbReplicaset' array to config.json.

Note that I've also added support for a Mongoose options object, which can be defined in a 'dbOptions' config.