### PR TITLE
Fix preview security

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -734,7 +734,7 @@ OutputPlugin.prototype.applyMenu = function(tenantId, courseId, jsonObject, dest
       // Get the menu type
       db.retrieve('menutype', {name: menuName}, {}, function(err, results) {
         if (err) {
-          callback(err, 'Unable to retrieve menutype with name ' + menuName);
+          return next(err, 'Unable to retrieve menutype with name ' + menuName);
         } else {
           if (results && results.length == 1) {
             var menu = results[0];
@@ -867,11 +867,7 @@ OutputManager.prototype.setupRoutes = function () {
         return res.json({success: false, message: error.message});
       }
       
-      logger.log('info', result);
       return res.json({success: true, payload: result});
-      // next(null, result);
-      // Redirect to preview
-      //res.redirect('/preview/' + user.tenant._id + '/' + courseId + '/main.html');
     });
   });
 

--- a/routes/preview/index.js
+++ b/routes/preview/index.js
@@ -7,9 +7,19 @@ var Constants = require('../../lib/outputmanager').Constants;
 var usermanager = require('../../lib/usermanager');
 var helpers = require('../../lib/helpers');
 var logger = require('../../lib/logger');
+var methodOverride = require('method-override');
+var util = require('util');
 
+server.use(methodOverride());
 server.set('views', __dirname);
 server.set('view engine', 'hbs');
+
+function PreviewPermissionError(message, httpCode) {
+  this.message = message || "Permission denied";
+  this.http_code = httpCode || 401;
+}
+
+util.inherits(PreviewPermissionError, Error);
 
 server.get('/preview/:tenant/:course/*', function (req, res, next) {
   var courseId = req.params.course,
@@ -20,7 +30,8 @@ server.get('/preview/:tenant/:course/*', function (req, res, next) {
     
   if (!user) {
     logger.log('warn', 'Preview: Unauthorised attempt to view course %s on tenant %s', courseId, tenantId);
-    return res.status(501).end();
+    
+    return next(new PreviewPermissionError());
   }
   
   var options = {
@@ -31,14 +42,16 @@ server.get('/preview/:tenant/:course/*', function (req, res, next) {
     // Compare the tenantId values
     if (tenantId !== user.tenant._id.toString()) {
       logger.log('warn', 'Preview: User %s does not have permission to view course %s on tenant %s', user._id, courseId, tenantId);
-      return res.status(404).end();
+      
+      return next(new PreviewPermissionError());
     }    
 
     // When requesting the first page, check the user has access to this course.
     helpers.hasCoursePermission('*', user._id, tenantId, {_id: courseId}, function(err, hasPermission) {
       if (err) {
         logger.log('error', err);
-        return res.status(404).end();
+        
+        return next(new PreviewPermissionError());
       }
       
       // Verify the session is configured to hold the course previews accessible for this user.
@@ -55,7 +68,8 @@ server.get('/preview/:tenant/:course/*', function (req, res, next) {
         }
         
         logger.log('warn', 'Preview: User %s does not have permission to view course %s on tenant %s', user._id, courseId, tenantId);
-        return res.status(404).end();
+
+        return next(new PreviewPermissionError());
       }
       
       // Store in the session that the user has access to this course.
@@ -66,27 +80,28 @@ server.get('/preview/:tenant/:course/*', function (req, res, next) {
           // Display the error to the user.
           res.status(err.status).end();
         }
-        // else {
-        //   console.log('Sent:', file);
-        // }
       });
     });
   } else {
     // Verify that the user has appropriate access to the requested file.
     if (req.session.previews && req.session.previews.indexOf(courseId) > -1) {
-      
       res.sendFile(file, options, function(err) {
         if (err) {
           // Display the error to the user.
           // We don't want to clog the log with 404s, etc.
           res.status(err.status).end();
         }
-        // else {
-        //   console.log('Sent:', file);
-        // }
       });
     } else {
       return res.status(404).end();
     }
   }
 });
+
+function errorHandler(err, req, res, next) {
+  var httpCode = err.http_code || 500;
+  res.status(httpCode);
+  res.render('error', {http_code: httpCode, error: err});
+}
+
+server.use(errorHandler);

--- a/routes/preview/index.js
+++ b/routes/preview/index.js
@@ -5,33 +5,81 @@ var server = module.exports = express();
 var configuration = require('../../lib/configuration');
 var Constants = require('../../lib/outputmanager').Constants;
 var usermanager = require('../../lib/usermanager');
+var helpers = require('../../lib/helpers');
+var logger = require('../../lib/logger');
 
 server.set('views', __dirname);
 server.set('view engine', 'hbs');
 
 server.get('/preview/:tenant/:course/*', function (req, res, next) {
-  var course = req.params.course,
-      tenant = req.params.tenant,
-      currentUser = usermanager.getCurrentUser(),
-      file = req.params[0] || 'main.html',
-      requestedFile = path.join(configuration.serverRoot, Constants.Folders.Temp, configuration.getConfig('masterTenantID'), Constants.Folders.Framework, Constants.Folders.AllCourses, tenant, course, Constants.Folders.Build, file);
-  var currentUrl = 'http://' + configuration.serverName  + ':' + configuration.serverPort + '/preview/' + tenant + '/' + course;
-
-  // TODO -- Cimplement security here
-  fs.exists(requestedFile, function (exists) {
-    if (!exists) {
-      // preview may have been removed by tenant config changes
-      return res.render('message', { url: currentUrl, title: "Generating preview...", message: "Your preview is taking some time to generate.  Please wait..." });
-    }
-
-    var isServerRequest = true;
-    if (isServerRequest || (currentUser && (currentUser.tenant._id == tenant))) {
-      res.sendFile(requestedFile);
+  var courseId = req.params.course,
+    tenantId = req.params.tenant,
+    user = usermanager.getCurrentUser(),
+    file = req.params[0] || Constants.Filenames.Main,
+    root = path.join(configuration.serverRoot, Constants.Folders.Temp, configuration.getConfig('masterTenantID'), Constants.Folders.Framework, Constants.Folders.AllCourses, tenantId, courseId, Constants.Folders.Build);
+    
+  if (!user) {
+    logger.log('warn', 'Preview: Unauthorised attempt to view course %s on tenant %s', courseId, tenantId);
+    return res.status(501).end();
+  }
+  
+  var options = {
+    root: root
+  };
+  
+  if (file == Constants.Filenames.Main) {
+    // When requesting the first page, check the user has access to this course.
+    helpers.hasCoursePermission('*', user._id, tenantId, {_id: courseId}, function(err, hasPermission) {
+      if (err) {
+        logger.log('error', err);
+      }
+      
+      // Verify the session is configured to hold the course previews accessible for this user.
+      if (!req.session.previews || Array.isArray(req.session.previews)) {
+        req.session.previews = [];
+      }
+      
+      if (!hasPermission) {
+        // Remove this course from the cached sessions.
+        var position = req.session.previews.indexOf(courseId);
+        
+        if (position > -1) {
+          req.session.previews.splice(position, 1);  
+        }
+        
+        logger.log('warn', 'Preview: User %s does not have permission to view course %s on tenant %s', user._id, courseId, tenantId);
+        return res.status(404).end();
+      }
+      
+      // Store in the session that the user has access to this course.
+      req.session.previews.push(courseId);
+      
+      res.sendFile(file, options, function(err) {
+        if (err) {
+          // Display the error to the user.
+          res.status(err.status).end();
+        }
+        // else {
+        //   console.log('Sent:', file);
+        // }
+      });
+    });
+  } else {
+    // Verify that the user has appropriate access to the requested file.
+    if (req.session.previews && req.session.previews.indexOf(courseId) > -1) {
+      
+      res.sendFile(file, options, function(err) {
+        if (err) {
+          // Display the error to the user.
+          // We don't want to clog the log with 404s, etc.
+          res.status(err.status).end();
+        }
+        // else {
+        //   console.log('Sent:', file);
+        // }
+      });
     } else {
-      // User doesn't have access to this course
-      res.statusCode = 500;
-      res.json({success: false});
-      return res.end();
+      return res.status(404).end();
     }
-  });
+  }
 });

--- a/routes/preview/index.js
+++ b/routes/preview/index.js
@@ -28,10 +28,17 @@ server.get('/preview/:tenant/:course/*', function (req, res, next) {
   };
   
   if (file == Constants.Filenames.Main) {
+    // Compare the tenantId values
+    if (tenantId !== user.tenant._id.toString()) {
+      logger.log('warn', 'Preview: User %s does not have permission to view course %s on tenant %s', user._id, courseId, tenantId);
+      return res.status(404).end();
+    }    
+
     // When requesting the first page, check the user has access to this course.
     helpers.hasCoursePermission('*', user._id, tenantId, {_id: courseId}, function(err, hasPermission) {
       if (err) {
         logger.log('error', err);
+        return res.status(404).end();
       }
       
       // Verify the session is configured to hold the course previews accessible for this user.


### PR DESCRIPTION
This PR closes preview URLs being accessible to anyone who had them. Now when a request is made to 'main.html', the code checks that the user has access to the course. If they do, the course is cached in the user's session, so that the permissions check is cached for subsequent requests (for images, CSS, etc.).