### PR TITLE
Fix the preview pop-up URL

### DIFF
--- a/frontend/src/core/editor/global/views/editorView.js
+++ b/frontend/src/core/editor/global/views/editorView.js
@@ -108,7 +108,7 @@ define(function(require){
       var courseId = Origin.editor.data.course.get('_id');
       var tenantId = Origin.sessionModel.get('tenantId');
 
-      window.open('/preview/' + tenantId + '/' + courseId + '/main.html', 'preview');
+      window.open('/preview/' + tenantId + '/' + courseId + '/index.html', 'preview');
     },
 
     previewProject: function(event) {


### PR DESCRIPTION
On clicking the "Preview" button, the popup window was pointing to the
course's 'main.html' file, which isn't generated by the grunt task. The
correct file is 'index.html'.

This happened to me on Windows, having cloned adapt_authoring v0.1.3. After following the installation steps and creating an initial course with some dummy content, the "Preview" button was opening a blank window, with the URL ending in 'main.html'. Chrome's developer tools showed a 404. After looking around the directory hierarchy I found the `repo_root\temp\<tenant-id>\adapt_framework\courses\<course-id>\build\` directory, which doesn't contain a 'main.html', but does have an 'index.html'. Manually changing the preview window's URL to index.html correctly displayed the course I had just created.

Searching issues and the wiki pages, #588 mentions that 'main.html' is/was the file that loads the course in an iframe (possibly for [SCORM previewing purposes][MainHtmlScormPreview]?), but the [changelog][ChangelogIframeRemoved] says iframe previews were removed back in January 2015. Is this a Windows-only issue maybe?

I saw that [adapt_framework's Gruntfile.js][AdaptFrameworkGruntfile] has a task that creates an 'index.html' so I `blame`d it to see if it was originally 'main.html', but it doesn't seem so.

I also noticed that in routes/preview/index.js, if there is no file specified it [defaults to `Constants.Filenames.Main`][PreviewRouteDefault], whose [value is 'main.html'][ConstantsFilenamesMain], so that might need updating too.

[MainHtmlScormPreview]: https://github.com/adaptlearning/adapt_framework/wiki/Setting-up-your-development-environment#viewing-the-build
[ChangelogIframeRemoved]: https://github.com/adaptlearning/adapt_authoring/blob/master/CHANGELOG.md#010---2015-01-26-dennis-heaney-dennislearningpoolcom
[AdaptFrameworkGruntfile]: https://github.com/adaptlearning/adapt_framework/blob/8f0e638add1d499e22c45ff3110b6f92802bd0de/Gruntfile.js#L72
[PreviewRouteDefault]: https://github.com/adaptlearning/adapt_authoring/blob/1f135b1f28621e63a03300fdf858f05c6bc9a1ec/routes/preview/index.js#L28
[ConstantsFilenamesMain]: https://github.com/adaptlearning/adapt_authoring/blob/1f135b1f28621e63a03300fdf858f05c6bc9a1ec/lib/outputmanager.js#L75