### PR TITLE
Setup jshint for code linting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,41 @@ module.exports = function(grunt) {
           }
         }
       },
+      jshint: {
+        options: {
+          reporter: require('jshint-stylish'),
+          curly: true,
+          undef: true,
+          asi: true,
+          eqnull: false,
+          sub: true
+        },
+        frontend: {
+          options: {
+            browser: true,
+            es3: true,
+            jquery: true,
+            globals: {
+              Backbone: false,
+              Handlebars: false,
+              _: false,
+              define: false,
+              require: false
+            }
+          },
+          files: {
+            src: ['frontend/src/core/**/*.js','!frontend/src/core/libraries/**/*.js']
+          }
+        },
+        backend: {
+          options: {
+            node: true
+          },
+          files: {
+            src: ['lib/**/*.js','plugins/**/*.js','!plugins/content/**','routes/**/*.js','!**/node_modules/**']
+          }
+        }
+      },
       requirejs: {
         dev: {
           options: {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,9 @@
   },
   "devDependencies": {
     "grunt-casperjs": "2.x",
+    "grunt-contrib-jshint": "^0.11.3",
     "grunt-mocha-test": "~0.7.0",
+    "jshint-stylish": "^2.1.0",
     "mocha": "~1.13.0",
     "phantom": "^0.6.5",
     "should": "~1.3.0",


### PR DESCRIPTION
Fixes #294.

Have had to split up the config settings (i.e. [defaults](https://github.com/adaptlearning/adapt_authoring/blob/issue/294/Gruntfile.js#L67-L74), [frontend](https://github.com/adaptlearning/adapt_authoring/blob/issue/294/Gruntfile.js#L76-L86)/[backend](https://github.com/adaptlearning/adapt_authoring/blob/issue/294/Gruntfile.js#L93-L95)) -- on account of the frontend/backend separation -- so can't have a .jshintrc file. If anyone can see a way around this, I'm more than happy to change it.