### PR TITLE
Fixes #995, sets the JSON payload limit to 5Mb

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -291,10 +291,9 @@ Origin.prototype.createServer = function (options, cb) {
     server.use(bodyParser.urlencoded({
       extended: true
     }));
-    server.use(bodyParser.json());
     server.use(methodOverride());
     server.use(cookieParser());
-    server.use(bodyParser.json({limit: '50mb'}));
+    server.use(bodyParser.json({limit: '5mb'}));
     server.use(bodyParser.urlencoded({limit: '50mb', extended: true}));
     server.use(session({
       key: 'connect.sid',


### PR DESCRIPTION
Previously this was defaulted to 100k.