### PR TITLE
Fixes #1003, resolves JavaScript error with ACE editor on new course

### DIFF
--- a/frontend/src/core/project/models/projectModel.js
+++ b/frontend/src/core/project/models/projectModel.js
@@ -14,7 +14,8 @@ define(function(require) {
 
     defaults: {
         'tags': [],
-        _type: 'course'
+        _type: 'course',
+        customStyle: ''
     },
 
     initialize : function(options) {


### PR DESCRIPTION
This was because the 'customStyle' attribute had not been set.