### PR TITLE
Resolves #1090, displays alert on delete project error

### DIFF
--- a/frontend/src/core/project/views/projectView.js
+++ b/frontend/src/core/project/views/projectView.js
@@ -109,10 +109,14 @@ define(function(require){
           self.remove()
         },
         error: function(model, response, options) {
-          Origin.Notify.alert({
-            type: 'error',
-            text: response.responseJSON.message
-          });
+          var errorMsg = function() {
+            Origin.Notify.alert({
+              type: 'error',
+              text: response.responseJSON.message
+            });
+          };
+          
+          _.delay(errorMsg, 1000);  
         }
       });
     },


### PR DESCRIPTION
This was caused by two sweet alert dialog boxes in quick succession.  Adding a delay seems to resolve this.