### PR TITLE
Fixes #1095

### DIFF
--- a/frontend/src/core/scaffold/scaffoldOverrides.js
+++ b/frontend/src/core/scaffold/scaffoldOverrides.js
@@ -99,14 +99,6 @@ define(function(require) {
 		this.$el.val(value);
 	}
 
-	Backbone.Form.editors.Checkbox.prototype.setValue = function(value) {
-		if (value || this.schema.default) {
-			this.$el.prop('checked', true);
-		}else {
-			this.$el.prop('checked', false);
-		}
-	}
-
 	Backbone.Form.editors.TextArea.prototype.render = function() {
 
 	    // Place value


### PR DESCRIPTION
With the override removed, the original [function](https://github.com/adaptlearning/adapt_authoring/blob/develop/frontend/src/core/libraries/backbone-forms.js#L1554-L1560) is called.

Initial population of schema defaults is handled [here](https://github.com/adaptlearning/adapt_authoring/blob/develop/lib/helpers.js#L31).