### PR TITLE
Fix issue with install script grabbing versions of plugins which aren't compatible with the framework core

### DIFF
--- a/install.js
+++ b/install.js
@@ -352,22 +352,12 @@ var steps = [
       var plugins = Object.keys(json.dependencies);
 
       async.eachSeries(plugins, function(plugin, pluginCallback) {
-        app.bowermanager.installPlugin(plugin, json.dependencies[plugin], function(err) {
-          if (err) {
-            return pluginCallback(err);
-          }
-
-          pluginCallback();
-        });
-
-      }, function(err) {
-        if (err) {
-          console.log(err);
-          return next(err);
+        if(json.dependencies[plugin] === '*') {
+          app.bowermanager.installLatestCompatibleVersion(plugin, pluginCallback);
+        } else {
+          app.bowermanager.installPlugin(plugin, json.dependencies[plugin], pluginCallback);
         }
-
-        next();
-      });
+      }, next);
     });
   },
   // configure the super awesome user

--- a/lib/bowermanager.js
+++ b/lib/bowermanager.js
@@ -6,7 +6,7 @@ var logger = require('./logger');
 var database = require('./database');
 var ncp = require('ncp').ncp;
 var mkdirp = require('mkdirp');
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var _ = require('underscore');
 var bowerOptions = require('../plugins/content/bower/defaults.json');
@@ -146,6 +146,55 @@ BowerManager.prototype.installPlugin = function(pluginName, pluginVersion, callb
       });
     });  
   });
+}
+
+/**
+* Wrapper for installPlugin which install the latest version that's compatible
+* with the installed framework.
+* @param {string} pluginName - The name of the Adapt plugin
+* @param {function} callback - Callback function
+ */
+BowerManager.prototype.installLatestCompatibleVersion = function (pluginName, callback) {
+  var self = this;
+    fs.readJson(path.join(app.configuration.getConfig('root'), 'version.json'), function(error, versionJson) {
+      if (error) {
+        logger.log('error', error);
+        return callback(err);
+      }
+      // Query bower to verify that the specified plugin exists.
+      bower.commands.search(pluginName, bowerOptions)
+        .on('error', callback)
+        .on('end', function (results) {
+          if (!results || results.length == 0) {
+            logger.log('warn', 'Plugin ' + packageName + ' not found!');
+            return callback('Plugin ' + packageName + ' not found!');
+          }
+          // The plugin exists -- remove any fuzzy matches, e.g. adapt-contrib-assessment would
+          // also bring in adapt-contrib-assessmentResults, etc.
+          var bowerPackage = _.findWhere(results, {name: pluginName});
+          bower.commands.info(bowerPackage.url)
+            .on('error', callback)
+            .on('end', function (latestInfo) {
+              // the versions will be in version order, rather than release date,
+              // so no need for ordering
+              var installedFrameworkVersion = versionJson.adapt_framework;
+              var requiredFrameworkVersion;
+              var index = -1;
+              async.doUntil(function iterator(cb) {
+                bower.commands.info(bowerPackage.url + '#' + latestInfo.versions[++index])
+                  .on('error', cb)
+                  .on('end', function (result) {
+                    requiredFrameworkVersion = result.framework;
+                    cb();
+                  });
+              }, function isCompatible() {
+                return semver.satisfies(installedFrameworkVersion, requiredFrameworkVersion);
+              }, function(error, version) {
+                self.installPlugin(pluginName, latestInfo.versions[index], callback);
+              });
+            });
+        });
+    });
 }
 
 /**


### PR DESCRIPTION
Fixes #1110 

Queries the bower repo to find the latest version that's compatible with the installed framework core. Any plugins with semver `*` in `adapt.json` will use the new `Bowermanager.installLatestCompatibleVersion` function, whereas specific versions use `Bowermanager.installPlugin` as before.

_**Testing tip**: add a `next();` at line 208 to skip the framework install. Depending on your internet connection, this can take a while._