### PR TITLE
Properties not appearing on-screen in same order as properties.schema

### DIFF
--- a/lib/dml/mongoose/index.js
+++ b/lib/dml/mongoose/index.js
@@ -452,7 +452,13 @@ MongooseDB.prototype.addSchema = function (modelName, schema) {
   schema = transformArrayAttributes(schema);
 
   if (!(schema instanceof mongoose.Schema)) { // might already be a mongoose schema
-    schema = mongoose.Schema(schema);
+    var options = {
+      toObject: {
+        retainKeyOrder: true
+      }
+    };
+
+    schema = mongoose.Schema(schema, options);
   }
 
   if (!(schema && schema instanceof mongoose.Schema)) { // must be a mongoose schema


### PR DESCRIPTION
Resolved the source of the issue with inverted properties. Turns out it is a quirk in MongoDB. The property 'retainKeyOrder' needed to be set on the schema options 'toObject' attribute (see here: http://mongoosejs.com/docs/api.html#document_Document-toObject). Properties will now be listed in the same order as defined in the schema file. For this to take effect on a component, a version bump is required.