### PR TITLE
Resolves #1150, re-work to MongoStore()

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -278,13 +278,8 @@ Origin.prototype.createServer = function (options, cb) {
 
     // new session store using connect-mongo (issue #544)
     var sessionStore = new MongoStore({
-      db: app.configuration.getConfig('dbName'),
-      auto_reconnect: true,
-      host: app.configuration.getConfig('dbHost'),
-      port: app.configuration.getConfig('dbPort'),
-      username: app.configuration.getConfig('dbUser'),
-      password: app.configuration.getConfig('dbPass')
-    });
+      mongooseConnection: db.conn
+    });  
 
     server.use(compression());
     /*server.use(favicon());*/

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bower": "1.6.5",
     "chalk": "^1.0.0",
     "compression": "^1.5.2",
-    "connect-mongo": "0.4.x",
+    "connect-mongo": "1.1.0",
     "consolidate": "0.10.0",
     "cookie-parser": "^1.3.5",
     "errorhandler": "^1.4.2",


### PR DESCRIPTION
The code has been updated to re-use the existing MongoDB connection.  The previous code also assumed a single instances, whereas re-using the connection allows support for MongoDB replicasets.