### PR TITLE
Resolves #1215, corrects a caching issue with course schemas

### DIFF
--- a/frontend/src/core/scaffold/scaffold.js
+++ b/frontend/src/core/scaffold/scaffold.js
@@ -191,7 +191,11 @@ define(function(require) {
         
       });
       
-      builtSchemas[type] = scaffoldSchema;
+      b// The 'course' schema is a special case as it is augmented depending
+      // on what plugins are enabled on the course.
+      if (type !== 'course') {
+        builtSchemas[type] = scaffoldSchema;
+      }
       
       return scaffoldSchema;  
     } catch (e) {

--- a/frontend/src/core/scaffold/scaffold.js
+++ b/frontend/src/core/scaffold/scaffold.js
@@ -178,29 +178,30 @@ define(function(require) {
 
 	var buildSchema = function(schema, options, type) {
 
-    try {
-      if (builtSchemas[type]) {
-        return builtSchemas[type];
-      }
+    	try {
+            // These types of schemas change frequently and cannot be cached.
+    	    var volatileTypes = ['course', 'config', 'article', 'block', 'component'];
 
-      var scaffoldSchema = {};
-          
-      _.each(schema, function(field, key) {
-        // Build schema
-        setupSchemaFields(field, key, schema, scaffoldSchema);
-        
-      });
-      
-      // The 'course' schema is a special case as it is augmented depending
-      // on what plugins are enabled on the course.
-      if (type !== 'course') {
-        builtSchemas[type] = scaffoldSchema;
-      }
-      
-      return scaffoldSchema;  
-    } catch (e) {
-      alert('buildSchema - ' + e.message);
-    }
+    	    if (_.indexOf(volatileTypes, type) == -1 && builtSchemas[type]) {
+    	       return builtSchemas[type];
+            }
+
+            var scaffoldSchema = {};
+
+            _.each(schema, function(field, key) {
+    	       // Build schema
+                setupSchemaFields(field, key, schema, scaffoldSchema);
+            });
+
+            // Only cache non-volatile types.
+            if (_.indexOf(volatileTypes, type) == -1) {
+                builtSchemas[type] = scaffoldSchema;
+            }
+
+            return scaffoldSchema;
+        } catch (e) {
+            alert('buildSchema - ' + e.message);
+        }
 	}
 
 	var buildFieldsets = function(schema, options) {

--- a/frontend/src/core/scaffold/scaffold.js
+++ b/frontend/src/core/scaffold/scaffold.js
@@ -191,7 +191,7 @@ define(function(require) {
         
       });
       
-      b// The 'course' schema is a special case as it is augmented depending
+      // The 'course' schema is a special case as it is augmented depending
       // on what plugins are enabled on the course.
       if (type !== 'course') {
         builtSchemas[type] = scaffoldSchema;

--- a/frontend/src/core/scaffold/schemas.js
+++ b/frontend/src/core/scaffold/schemas.js
@@ -18,7 +18,7 @@ define(function(require) {
             });
 
             // Get the schema
-            var schema = _.clone(Origin.schemas.get(schemaName));
+            var schema = JSON.parse(JSON.stringify(Origin.schemas.get(schemaName)));
             // Compare the enabledExtensions against the current schemas
             if (schema._extensions) {
                 _.each(schema._extensions.properties, function(value, key) {
@@ -65,7 +65,7 @@ define(function(require) {
 			return schema;
 
 		} else {
-            var schema = _.clone(Origin.schemas.get(schemaName));
+            var schema = JSON.parse(JSON.stringify(Origin.schemas.get(schemaName)));
             delete schema._extensions;
             // Remove globals as these are appended to the course model
             delete schema.globals;


### PR DESCRIPTION
This could manifest itself when editing Project Settings whereby extensions or global text strings would apparently disappear from the course.

There were two fundamental problems with the previous code:
- The _.clone() function only provides a shallow-copied clone. Nested objects, such as '_extensions' are copied by reference.
- In scaffold.js, the builtSchemas variable which is being used as a cache for previously generated schemas, should not persist the 'course' schema becuase it is dependent on which plugins are enabled or in use on a course.