### PR TITLE
Resolves #1289, adds support for negative numbers in 'number' validation

### DIFF
--- a/frontend/src/core/libraries/backbone-forms.js
+++ b/frontend/src/core/libraries/backbone-forms.js
@@ -553,7 +553,7 @@ Form.validators = (function() {
     options = _.extend({
       type: 'number',
       message: this.errMessages.number,
-      regexp: /^[0-9]*\.?[0-9]*?$/
+      regexp: /^-?[0-9]*\.?[0-9]*?$/
     }, options);
     
     return validators.regexp(options);
@@ -1454,7 +1454,8 @@ Form.editors.Number = Form.editors.Text.extend({
       newVal = newVal + String.fromCharCode(event.charCode);
     }
 
-    var numeric = /^[0-9]*\.?[0-9]*?$/.test(newVal);
+    // Allow support for negative numbers.
+    var numeric = /^-?[0-9]*\.?[0-9]*?$/.test(newVal);
 
     if (numeric) {
       delayedDetermineChange();


### PR DESCRIPTION
This has been patched in backbone-forms.js directly.  We should consider upgrading the entire library in a future release.