### PR TITLE
Fixed issue with uploading plugins

### DIFF
--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -897,11 +897,11 @@ function handleUploadedPlugin (req, res, next) {
         fs.readdir(outputPath, function (err, directoryList) {
 
           async.some(directoryList, function(directory, asyncCallback) {
-            var bowerPath = path.join(outputPath, directory, 'bower.json');
+            var bowerPath = path.join(outputPath, 'bower.json');
 
             fs.exists(bowerPath, function(exists) {
               if (exists) {
-                canonicalDir = path.join(outputPath, directory);
+                canonicalDir = outputPath;
                 try {
                   packageJson = require(bowerPath);
                 } catch (error) {


### PR DESCRIPTION
Tested on Ubuntu. 

There is a bug that it looks for files in the wrong place (or the guide on how to build plugins is wrong).