### PR TITLE
Persist dashboard prefs & add browser storage plugin

### DIFF
--- a/frontend/src/core/app/views/originView.js
+++ b/frontend/src/core/app/views/originView.js
@@ -51,24 +51,23 @@ define(function(require){
       Origin.trigger('router:hideLoading');
     },
 
-    setUserPreference: function(key, value) {
-      if (this.settings.preferencesKey && typeof(Storage) !== "undefined") {
-        // Get preferences for this view
+    setUserPreference: function(key, value, sessionOnly) {
+      if (this.settings.preferencesKey) {
         var preferences = (Origin.sessionModel.get(this.settings.preferencesKey) || {});
-        // Set key and value
         preferences[key] = value;
-        // Store in localStorage
+        // Store in session model
         Origin.sessionModel.set(this.settings.preferencesKey, preferences);
-        
+        // set in browser storage
+        var data = {};
+        data[key] = value;
+        Origin.browserStorage.set(this.settings.preferencesKey, data, sessionOnly || false, false);
       }
     },
 
     getUserPreferences: function() {
-      if (this.settings.preferencesKey && typeof(Storage) !== "undefined"
-        && localStorage.getItem(this.settings.preferencesKey)) {
-        return Origin.sessionModel.get(this.settings.preferencesKey);
-      } else {
-        return {};
+      if (this.settings.preferencesKey) {
+        var saveData = Origin.browserStorage.get(this.settings.preferencesKey);
+        return saveData || {};
       }
     },
 

--- a/frontend/src/core/dashboard/views/dashboardView.js
+++ b/frontend/src/core/dashboard/views/dashboardView.js
@@ -108,7 +108,7 @@ define(function(require){
         title: 1
       };
 
-      this.setUserPreference('sort','asc');
+      this.setUserPreference('sort','asc', true);
       if (shouldRenderProjects) {
 
         this.updateCollection(true);
@@ -123,7 +123,7 @@ define(function(require){
         title: -1
       }
 
-      this.setUserPreference('sort','desc');
+      this.setUserPreference('sort','desc', true);
 
       if (shouldRenderProjects) {
 
@@ -139,7 +139,7 @@ define(function(require){
         updatedAt: -1
       }
 
-      this.setUserPreference('sort','updated');
+      this.setUserPreference('sort','updated', true);
 
       if (shouldRenderProjects) {
 
@@ -165,9 +165,9 @@ define(function(require){
       if (userPreferences) {
         var searchString = (userPreferences.search || '');
         this.search = this.convertFilterTextToPattern(searchString);
-        this.setUserPreference('search', searchString);
+        this.setUserPreference('search', searchString, true);
         this.tags = (_.pluck(userPreferences.tags, 'id') || []);
-        this.setUserPreference('tags', userPreferences.tags);
+        this.setUserPreference('tags', userPreferences.tags, true);
       }
 
       // Check if sort is set and sort the collection
@@ -306,12 +306,12 @@ define(function(require){
     filterBySearchInput: function (filterText) {
       this.filterText = filterText;
       this.search = this.convertFilterTextToPattern(filterText);
-      this.setUserPreference('search', filterText);
+      this.setUserPreference('search', filterText, true);
       this.updateCollection(true);
     },
 
     filterCoursesByTags: function(tags) {
-      this.setUserPreference('tags', tags);
+      this.setUserPreference('tags', tags, true);
       this.tags = _.pluck(tags, 'id');
       this.updateCollection(true);
     },

--- a/frontend/src/plugins/browserStorage/index.js
+++ b/frontend/src/plugins/browserStorage/index.js
@@ -1,0 +1,58 @@
+// LICENCE https://github.com/adaptlearning/adapt_authoring/blob/master/LICENSE
+/**
+ * TODO Look into setting this up like Notify with registered plugins 
+ */
+define(function(require) {
+  // don't bother doing anything if there's no storage
+  if(!Storage) return;
+  
+  var _ = require('underscore');
+  var Origin = require('coreJS/app/origin');
+
+  var userData = false;
+  
+  var BrowserStorage = {
+    initialise: function() {
+      var userId = Origin.sessionModel.get('id');
+      userData = {
+        local: JSON.parse(localStorage.getItem(userId)) || {}, 
+        session: JSON.parse(sessionStorage.getItem(userId)) || {}
+      };      
+    },
+
+    set: function(key, value, sessionOnly, replaceExisting) {
+      // TODO messy & only handles objects
+      if(sessionOnly === true) {
+        if(replaceExisting) userData.session[key] = value;
+        else userData.session[key] = _.extend({}, userData.session[key], value);
+      } else {
+        if(replaceExisting) userData.local[key] = value;
+        else userData.local[key] = _.extend({}, userData.local[key], value);
+      }
+      this.save();
+    },
+
+    get: function(key) {
+      var value = _.extend({}, userData.local[key], userData.session[key]);
+      return value;
+    },
+
+    // persist data to Storage
+    save: function() {
+      var userId = Origin.sessionModel.get('id');
+
+      if(!_.isEmpty(userData.session)) {
+        sessionStorage.setItem(userId, JSON.stringify(userData.session));
+      }
+      if(!_.isEmpty(userData.local)) {
+        localStorage.setItem(userId, JSON.stringify(userData.local));
+      }
+    }
+  };
+
+  // init
+  Origin.on('app:dataReady login:changed', function() {
+    BrowserStorage.initialise();
+    Origin.browserStorage = BrowserStorage;
+  });
+});


### PR DESCRIPTION
Prototype plugin to utilise WebStorage. Enables ability to save data to both session and local storage (fixes #1337).

Includes functionality to save dashboard view to localStorage & sort/search/filtering to sessionStorage (fixes #1336).

Saves data in the WebStorage per user ID, so you get something like:
```
USER_ID: {
   "prefsKey": "value"
}
```
or in our dashboard example:
```
578e4dae41a8045c06f20ce0: {
   "dashboard": {
      "layout": "thumb"
   } 
}
```