### PR TITLE
Add ability for JSON editor

### DIFF
--- a/frontend/src/core/scaffold/scaffold.js
+++ b/frontend/src/core/scaffold/scaffold.js
@@ -108,7 +108,7 @@ define(function(require) {
 				setupSchemaFields(field, key, objectSchema, scaffoldObjectSchema);
 			});
 			
-		} else if (field.type != 'object') {
+		} else if (field.type != 'object' || field.inputType) {
 
 			var validators = [];
 			// Go through each validator checking whether this is a default

--- a/frontend/src/core/scaffold/views/scaffoldCodeEditorView.js
+++ b/frontend/src/core/scaffold/views/scaffoldCodeEditorView.js
@@ -10,13 +10,23 @@ define(function(require) {
         tagName: 'div',
 
         className: 'scaffold-code-editor',
-        
+
+        isSyntaxError: false,
+
         initialize: function(options) {
             // Call parent constructor
             Backbone.Form.editors.Base.prototype.initialize.call(this, options);
             
             // Check which mode the code editor should be in
-            var schemaParts = options.schema.fieldType.split(':');
+            var fieldType = options.schema.fieldType;
+            var mode = fieldType.mode;
+
+            if (mode) {
+                this.mode = mode;
+                return;
+            }
+
+            var schemaParts = fieldType.split(':');
             
             if (schemaParts.length == 1) {
               this.mode = 'text';
@@ -26,23 +36,74 @@ define(function(require) {
         },
         
         render: function() {
-            // Place value
-            var self = this;
-            
+            this.setValue(this.value);
+
             _.defer(_.bind(function() {
                 window.ace.config.set("basePath", "./adaptbuilder/js/ace");
-                this.editor = window.ace.edit(self.$el[0]);
+                this.editor = window.ace.edit(this.$el[0]);
+
+                var session = this.editor.getSession();
+
                 this.editor.$blockScrolling = Infinity;
                 this.editor.setTheme("ace/theme/chrome");
-                this.editor.getSession().setMode("ace/mode/" + this.mode);
-                this.editor.setValue(self.value);
+                session.setMode("ace/mode/" + this.mode);
+                session.on('changeAnnotation', _.bind(this.onChangeAnnotation, this));
+                this.editor.setValue(this.value);
             }, this));
             
             return this;
         },
 
+        setValue: function(value) {
+            var schemaDefault = this.schema.default;
+            var fallbackDefault = this.mode === 'json' ? {} : '';
+
+            if (value === null) {
+                value = schemaDefault !== undefined ? schemaDefault : fallbackDefault;
+            }
+            if (this.mode === 'json') {
+                value = JSON.stringify(value, null, '\t');
+            }
+
+            this.value = value;
+        },
+
         getValue: function() {
-          return this.editor.getValue();
+            if (this.mode === 'json' && !this.isSyntaxError) {
+                return JSON.parse(this.editor.getValue() || null);
+            }
+
+            return this.editor.getValue();
+        },
+
+        validate: function() {
+            var error = Backbone.Form.editors.Base.prototype.validate.call(this);
+
+            if (error) {
+                return error;
+            }
+            if (this.isSyntaxError) {
+                return { message: 'Syntax error' };
+            }
+        },
+
+        onChangeAnnotation: function() {
+            var annotations = this.editor.getSession().getAnnotations();
+
+            for (var i = 0, j = annotations.length; i < j; i++) {
+                if (annotations[i].type === 'error') {
+                    this.isSyntaxError = true;
+                    return;
+                }
+            }
+
+            this.isSyntaxError = false;
+        },
+
+        remove: function() {
+            this.editor.getSession().off('changeAnnotation');
+
+            Backbone.Form.editors.Base.prototype.remove.call(this);
         }
 
     }, {


### PR DESCRIPTION
Example schema:
```json
"type": "object",
"default": {},
"inputType": {
  "type": "CodeEditor",
  "mode": "json"
}
```
Resolves https://github.com/adaptlearning/adapt_authoring/issues/1326.