### PR TITLE
pm2 processes.json fix

### DIFF
--- a/processes.json
+++ b/processes.json
@@ -2,7 +2,7 @@
   "apps" : [{
   "name"         : "adapt",
   "script"       : "server.js",
-  "watch"        : ["lib", "plugins", "conf", "routes", "server.js"],
+  "watch"        : ["lib", "conf", "routes", "server.js"],
   "ignore_watch" : ["temp", "data", "node_modules"],
   "watch_options": {
     "followSymLinks": false


### PR DESCRIPTION
when uploading plugins, pm2 restarts the app while uploading the plugin. this causes the plugin upload to fail

removed "plugins" folder frow watch list to fix this issue