### PR TITLE
custom smtp Service

### DIFF
--- a/conf/config-sample.json
+++ b/conf/config-sample.json
@@ -14,6 +14,7 @@
   "dbPort": 27017,
   "useSmtp": false,
   "smtpService": "",
+  "smtpConnectionUrl": "",
   "smtpUsername": "",
   "smtpPassword": "",
   "fromAddress": "",

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -22,14 +22,13 @@ var Mailer = function () {
     var errors = [];
 
     if (this.service === '' && !this.useSmtpUrl) {
+    	// neither valid service nor smtpUrl defined, fail imediately 
       errors.push('smtpService as a well-known Service or a smtpConnectionUrl is required');
-    } else {
-      if (!this.useSmtpUrl) {
-        if (this.service === '') errors.push('smtpService as a well-known Service');
-        if (this.user === '') errors.push('smtpUsername');
-        if (this.pass === '') errors.push('smtpPassword');
-        if (this.from === '') errors.push('fromAddress');
-      }
+    } else if (!this.useSmtpUrl) {
+    	// check if required options for servie are available 
+			if (this.user === '') errors.push('smtpUsername');
+			if (this.pass === '') errors.push('smtpPassword');
+			if (this.from === '') errors.push('fromAddress');
     }
 
     if (errors.length > 0) {
@@ -50,7 +49,7 @@ var Mailer = function () {
     };
   }
 
-  // Configure the credentials for the specified sevice
+  // Configure the credentials for the specified service
   // See http://www.nodemailer.com/ for options
   this.transporter = nodemailer.createTransport(smtpConfig);
 };

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -13,26 +13,33 @@ var Mailer = function () {
   this.user = configuration.getConfig('smtpUsername');
   this.pass = configuration.getConfig('smtpPassword');
   this.from = configuration.getConfig('fromAddress');
+  this.connectionUrl = configuration.getConfig('smtpConnectionUrl');
 
-  this.useSmtpUrl = this.service.startsWith('smtp');
+  this.useSmtpUrl = this.connectionUrl.startsWith('smtp');
 
   // check that required settings exist
   this.validateSettings = function() {
     var errors = [];
 
-    if(this.service === '') errors.push('smtpService as a smtp URL or well-known Service');
-    if(this.user === '' && !this.useSmtpUrl) errors.push('smtpUsername');
-    if(this.pass === '' && !this.useSmtpUrl) errors.push('smtpPassword');
-    if(this.from === '') errors.push('fromAddress');
+    if (this.service === '' && !this.useSmtpUrl) {
+      errors.push('smtpService as a well-known Service or a smtpConnectionUrl is required');
+    } else {
+      if (!this.useSmtpUrl) {
+        if (this.service === '') errors.push('smtpService as a well-known Service');
+        if (this.user === '') errors.push('smtpUsername');
+        if (this.pass === '') errors.push('smtpPassword');
+        if (this.from === '') errors.push('fromAddress');
+      }
+    }
 
-    if(errors.length > 0) {
+    if (errors.length > 0) {
       throw new Error('Mailer requires the following settings to function: ' + errors.toString());
     }
   };
 
   var smtpConfig;
   if (this.useSmtpUrl) {
-    smtpConfig = this.service;
+    smtpConfig = this.connectionUrl;
   } else {
     smtpConfig = {
       service: this.service,

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -14,13 +14,15 @@ var Mailer = function () {
   this.pass = configuration.getConfig('smtpPassword');
   this.from = configuration.getConfig('fromAddress');
 
+  this.useSmtpUrl = this.service.startsWith('smtp');
+
   // check that required settings exist
   this.validateSettings = function() {
     var errors = [];
 
-    if(this.service === '') errors.push('smtpService');
-    if(this.user === '') errors.push('smtpUsername');
-    if(this.pass === '') errors.push('smtpPassword');
+    if(this.service === '') errors.push('smtpService as a smtp URL or well-known Service');
+    if(this.user === '' && !this.useSmtpUrl) errors.push('smtpUsername');
+    if(this.pass === '' && !this.useSmtpUrl) errors.push('smtpPassword');
     if(this.from === '') errors.push('fromAddress');
 
     if(errors.length > 0) {
@@ -28,15 +30,22 @@ var Mailer = function () {
     }
   };
 
+  var smtpConfig;
+  if (this.useSmtpUrl) {
+    smtpConfig = this.service;
+  } else {
+    smtpConfig = {
+      service: this.service,
+      auth: {
+        user: this.user,
+        pass: this.pass
+      }
+    };
+  }
+
   // Configure the credentials for the specified sevice
   // See http://www.nodemailer.com/ for options
-  this.transporter = nodemailer.createTransport({
-    service: this.service,
-    auth: {
-      user: this.user,
-      pass: this.pass
-    }
-  });
+  this.transporter = nodemailer.createTransport(smtpConfig);
 };
 
 Mailer.prototype.send = function (toAddress, subject, text, templateData, callback) {


### PR DESCRIPTION
refactored so that a custom connection URL (`smtps://user%40gmail.com:pass@smtp.gmail.com/?pool=true`) can be passed as a smtpService config option.

#1447 