### PR TITLE
fixes #1611

### DIFF
--- a/frontend/src/core/editor/page/views/editorComponentListView.js
+++ b/frontend/src/core/editor/page/views/editorComponentListView.js
@@ -82,11 +82,7 @@ define(function(require) {
         var properties = componentType.get('properties');
         if (properties && properties.hasOwnProperty('_supportedLayout')) {
           var supportedLayout = properties._supportedLayout.enum;
-          var availablePositions = {
-            left: true,
-            right: true,
-            full: true
-          };
+          var availablePositions = _.clone(this.availablePositions);
 
           // Prune the available positions
           if (_.indexOf(supportedLayout, 'half-width') == -1) {

--- a/frontend/src/core/editor/page/views/editorComponentListView.js
+++ b/frontend/src/core/editor/page/views/editorComponentListView.js
@@ -7,123 +7,129 @@ define(function(require) {
   var EditorComponentListItemView = require('editorPage/views/editorComponentListItemView');
 
   var EditorComponentListView = EditorOriginView.extend({
-    tagName: "div",
-    className: "editor-component-list",
+      tagName: "div",
+      className: "editor-component-list",
 
-    events: {
-      'click': 'onOverlayClicked',
-      'click .editor-component-list-sidebar-exit, .click-capture': 'closeView',
-      'keyup .editor-component-list-sidebar-search input': 'onSearchKeyup'
-    },
+      events: {
+        'click': 'onOverlayClicked',
+        'click .editor-component-list-sidebar-exit, .click-capture': 'closeView',
+        'keyup .editor-component-list-sidebar-search input': 'onSearchKeyup'
+      },
 
-    preRender: function(options) {
-      $('html').css('overflow-y', 'hidden');
+      preRender: function(options) {
+        $('html').css('overflow-y', 'hidden');
 
-      this.listenTo(Origin, 'editorComponentListView:remove', this.remove);
-      this.listenTo(Origin, 'window:resize', this.onScreenResize);
+        this.listenTo(Origin, 'editorComponentListView:remove', this.remove);
+        this.listenTo(Origin, 'window:resize', this.onScreenResize);
 
-      this.setupCollection();
-      this.setupFilters();
+        this.setupCollection();
+        this.setupFilters();
 
-      this.$parentElement = options.$parentElement;
-      this.parentView = options.parentView;
-    },
+        this.$parentElement = options.$parentElement;
+        this.parentView = options.parentView;
+      },
 
-    setupCollection: function() {
-      var availableComponents = _.where(this.model.get('componentTypes'), { _isAvailableInEditor: true });
-      this.collection = new Backbone.Collection(availableComponents);
-    },
+      setupCollection: function() {
+        var availableComponents = _.where(this.model.get('componentTypes'), { _isAvailableInEditor: true });
+        this.collection = new Backbone.Collection(availableComponents);
+      },
 
-    setupFilters: function() {
-      this.availablePositions = {
-        left: false,
-        right: false,
-        full: false
-      };
+      setupFilters: function() {
+        this.availablePositions = {
+          left: false,
+          right: false,
+          full: false
+        };
 
-      _.each(this.model.get('layoutOptions'), function(layoutOption) {
-        switch(layoutOption.type) {
-          case 'left':
-            this.availablePositions.left = true;
-            break;
-          case 'right':
-            this.availablePositions.right = true;
-            break;
-          case 'full':
-            this.availablePositions.full = true;
-            break;
-        }
-      }, this);
+        _.each(this.model.get('layoutOptions'), function(layoutOption) {
+          switch(layoutOption.type) {
+            case 'left':
+              this.availablePositions.left = true;
+              break;
+            case 'right':
+              this.availablePositions.right = true;
+              break;
+            case 'full':
+              this.availablePositions.full = true;
+              break;
+          }
+        }, this);
 
-      this.model.set('_availablePosition', this.availablePositions);
-    },
+        this.model.set('_availablePosition', this.availablePositions);
+      },
 
-    postRender: function() {
-      this.renderComponentList();
-      this.headerHeight = this.$('.editor-component-list-sidebar-header').height();
-      $(window).resize();
-      // move bar into place and animate in
-      this.$el.css({ right:this.$('.editor-component-list-sidebar').width()*-1}).animate({ right:"0" }, 400,"easeOutQuart");
-    },
+      postRender: function() {
+        this.renderComponentList();
+        this.headerHeight = this.$('.editor-component-list-sidebar-header').height();
+        $(window).resize();
+        // move bar into place and animate in
+        this.$el.css({ right:this.$('.editor-component-list-sidebar').width()*-1}).animate({ right:"0" }, 400,"easeOutQuart");
+      },
 
-    closeView: function() {
-      var self = this;
-      this.$el.animate({ right:this.$('.editor-component-list-sidebar').width() *- 1 }, 400,"easeOutQuart", function onAnimOut() {
-        $('html').css('overflow-y', '');
-        self.remove();
-      });
-    },
+      closeView: function() {
+        var self = this;
+        this.$el.animate({ right:this.$('.editor-component-list-sidebar').width() *- 1 }, 400,"easeOutQuart", function onAnimOut() {
+          $('html').css('overflow-y', '');
+          self.remove();
+        });
+      },
 
-    renderComponentList: function() {
-      Origin.trigger('editorComponentListView:removeSubviews');
-      // _.each(this.collection, function(componentType) {
-      this.collection.each(function(componentType) {
-        var properties = componentType.get('properties');
-        if (properties && properties.hasOwnProperty('._supportedLayout')) {
-          var supportedLayout = properties.hasOwnProperty('._supportedLayout').enum;
+      renderComponentList: function() {
+        Origin.trigger('editorComponentListView:removeSubviews');
+        // _.each(this.collection, function(componentType) {
 
-          // Prune the available positions
-          if (_.indexOf(supportedLayout, 'half-width') == -1) {
-            this.availablePositions.left = false;
-            this.availablePositions.right = false;
+        this.collection.each(function(componentType) {
+          var properties = componentType.get('properties');
+          if (properties && properties.hasOwnProperty('_supportedLayout')) {
+            var supportedLayout = properties._supportedLayout.enum;
+            var availablePositions = {
+              left: true,
+              right: true,
+              full: true
+            };
+
+            // Prune the available positions
+            if (_.indexOf(supportedLayout, 'half-width') == -1) {
+              availablePositions.left = false;
+              availablePositions.right = false;
+            }
+
+            if (_.indexOf(supportedLayout, 'full-width') == -1) {
+              availablePositions.full = false;
+            }
           }
 
-          if (_.indexOf(supportedLayout, 'full-width') == -1) {
-            this.availablePositions.full = false;
-          }
-        }
-
-        this.$('.editor-component-list-sidebar-list').append(new EditorComponentListItemView({
+          this.$('.editor-component-list-sidebar-list').append(new EditorComponentListItemView({
             model: componentType,
-            availablePositions: this.availablePositions,
+            availablePositions: availablePositions,
             _parentId: this.model.get('_parentId'),
             $parentElement: this.$parentElement,
             parentView: this.parentView,
             searchTerms: componentType.get('displayName').toLowerCase()
           }).$el);
-      }, this);
-    },
+        }, this);
+      },
 
-    onOverlayClicked: function(event) {
-      if ($(event.target).hasClass('editor-component-list')) {
-        Origin.trigger('editorComponentListView:removeSubviews');
-        $('html').css('overflow-y', '');
-        this.remove();
+      onOverlayClicked: function(event) {
+        if ($(event.target).hasClass('editor-component-list')) {
+          Origin.trigger('editorComponentListView:removeSubviews');
+          $('html').css('overflow-y', '');
+          this.remove();
+        }
+      },
+
+      onSearchKeyup: function(event) {
+        var searchValue = $(event.currentTarget).val();
+        Origin.trigger('editorComponentListView:searchKeyup', searchValue);
+      },
+
+      onScreenResize: function(windowWidth, windowHeight) {
+        this.$('.editor-component-list-sidebar-list').height(windowHeight - this.headerHeight);
       }
     },
-
-    onSearchKeyup: function(event) {
-      var searchValue = $(event.currentTarget).val();
-      Origin.trigger('editorComponentListView:searchKeyup', searchValue);
-    },
-
-    onScreenResize: function(windowWidth, windowHeight) {
-      this.$('.editor-component-list-sidebar-list').height(windowHeight - this.headerHeight);
-    }
-  },
-  {
-    template: 'editorComponentList'
-  });
+    {
+      template: 'editorComponentList'
+    });
 
   return EditorComponentListView;
 });

--- a/frontend/src/core/editor/page/views/editorComponentListView.js
+++ b/frontend/src/core/editor/page/views/editorComponentListView.js
@@ -7,129 +7,129 @@ define(function(require) {
   var EditorComponentListItemView = require('editorPage/views/editorComponentListItemView');
 
   var EditorComponentListView = EditorOriginView.extend({
-      tagName: "div",
-      className: "editor-component-list",
+    tagName: "div",
+    className: "editor-component-list",
 
-      events: {
-        'click': 'onOverlayClicked',
-        'click .editor-component-list-sidebar-exit, .click-capture': 'closeView',
-        'keyup .editor-component-list-sidebar-search input': 'onSearchKeyup'
-      },
+    events: {
+      'click': 'onOverlayClicked',
+      'click .editor-component-list-sidebar-exit, .click-capture': 'closeView',
+      'keyup .editor-component-list-sidebar-search input': 'onSearchKeyup'
+    },
 
-      preRender: function(options) {
-        $('html').css('overflow-y', 'hidden');
+    preRender: function(options) {
+      $('html').css('overflow-y', 'hidden');
 
-        this.listenTo(Origin, 'editorComponentListView:remove', this.remove);
-        this.listenTo(Origin, 'window:resize', this.onScreenResize);
+      this.listenTo(Origin, 'editorComponentListView:remove', this.remove);
+      this.listenTo(Origin, 'window:resize', this.onScreenResize);
 
-        this.setupCollection();
-        this.setupFilters();
+      this.setupCollection();
+      this.setupFilters();
 
-        this.$parentElement = options.$parentElement;
-        this.parentView = options.parentView;
-      },
+      this.$parentElement = options.$parentElement;
+      this.parentView = options.parentView;
+    },
 
-      setupCollection: function() {
-        var availableComponents = _.where(this.model.get('componentTypes'), { _isAvailableInEditor: true });
-        this.collection = new Backbone.Collection(availableComponents);
-      },
+    setupCollection: function() {
+      var availableComponents = _.where(this.model.get('componentTypes'), { _isAvailableInEditor: true });
+      this.collection = new Backbone.Collection(availableComponents);
+    },
 
-      setupFilters: function() {
-        this.availablePositions = {
-          left: false,
-          right: false,
-          full: false
-        };
+    setupFilters: function() {
+      this.availablePositions = {
+        left: false,
+        right: false,
+        full: false
+      };
 
-        _.each(this.model.get('layoutOptions'), function(layoutOption) {
-          switch(layoutOption.type) {
-            case 'left':
-              this.availablePositions.left = true;
-              break;
-            case 'right':
-              this.availablePositions.right = true;
-              break;
-            case 'full':
-              this.availablePositions.full = true;
-              break;
-          }
-        }, this);
-
-        this.model.set('_availablePosition', this.availablePositions);
-      },
-
-      postRender: function() {
-        this.renderComponentList();
-        this.headerHeight = this.$('.editor-component-list-sidebar-header').height();
-        $(window).resize();
-        // move bar into place and animate in
-        this.$el.css({ right:this.$('.editor-component-list-sidebar').width()*-1}).animate({ right:"0" }, 400,"easeOutQuart");
-      },
-
-      closeView: function() {
-        var self = this;
-        this.$el.animate({ right:this.$('.editor-component-list-sidebar').width() *- 1 }, 400,"easeOutQuart", function onAnimOut() {
-          $('html').css('overflow-y', '');
-          self.remove();
-        });
-      },
-
-      renderComponentList: function() {
-        Origin.trigger('editorComponentListView:removeSubviews');
-        // _.each(this.collection, function(componentType) {
-
-        this.collection.each(function(componentType) {
-          var properties = componentType.get('properties');
-          if (properties && properties.hasOwnProperty('_supportedLayout')) {
-            var supportedLayout = properties._supportedLayout.enum;
-            var availablePositions = {
-              left: true,
-              right: true,
-              full: true
-            };
-
-            // Prune the available positions
-            if (_.indexOf(supportedLayout, 'half-width') == -1) {
-              availablePositions.left = false;
-              availablePositions.right = false;
-            }
-
-            if (_.indexOf(supportedLayout, 'full-width') == -1) {
-              availablePositions.full = false;
-            }
-          }
-
-          this.$('.editor-component-list-sidebar-list').append(new EditorComponentListItemView({
-            model: componentType,
-            availablePositions: availablePositions,
-            _parentId: this.model.get('_parentId'),
-            $parentElement: this.$parentElement,
-            parentView: this.parentView,
-            searchTerms: componentType.get('displayName').toLowerCase()
-          }).$el);
-        }, this);
-      },
-
-      onOverlayClicked: function(event) {
-        if ($(event.target).hasClass('editor-component-list')) {
-          Origin.trigger('editorComponentListView:removeSubviews');
-          $('html').css('overflow-y', '');
-          this.remove();
+      _.each(this.model.get('layoutOptions'), function(layoutOption) {
+        switch(layoutOption.type) {
+          case 'left':
+            this.availablePositions.left = true;
+            break;
+          case 'right':
+            this.availablePositions.right = true;
+            break;
+          case 'full':
+            this.availablePositions.full = true;
+            break;
         }
-      },
+      }, this);
 
-      onSearchKeyup: function(event) {
-        var searchValue = $(event.currentTarget).val();
-        Origin.trigger('editorComponentListView:searchKeyup', searchValue);
-      },
+      this.model.set('_availablePosition', this.availablePositions);
+    },
 
-      onScreenResize: function(windowWidth, windowHeight) {
-        this.$('.editor-component-list-sidebar-list').height(windowHeight - this.headerHeight);
+    postRender: function() {
+      this.renderComponentList();
+      this.headerHeight = this.$('.editor-component-list-sidebar-header').height();
+      $(window).resize();
+      // move bar into place and animate in
+      this.$el.css({ right:this.$('.editor-component-list-sidebar').width()*-1}).animate({ right:"0" }, 400,"easeOutQuart");
+    },
+
+    closeView: function() {
+      var self = this;
+      this.$el.animate({ right:this.$('.editor-component-list-sidebar').width() *- 1 }, 400,"easeOutQuart", function onAnimOut() {
+        $('html').css('overflow-y', '');
+        self.remove();
+      });
+    },
+
+    renderComponentList: function() {
+      Origin.trigger('editorComponentListView:removeSubviews');
+      // _.each(this.collection, function(componentType) {
+
+      this.collection.each(function(componentType) {
+        var properties = componentType.get('properties');
+        if (properties && properties.hasOwnProperty('_supportedLayout')) {
+          var supportedLayout = properties._supportedLayout.enum;
+          var availablePositions = {
+            left: true,
+            right: true,
+            full: true
+          };
+
+          // Prune the available positions
+          if (_.indexOf(supportedLayout, 'half-width') == -1) {
+            availablePositions.left = false;
+            availablePositions.right = false;
+          }
+
+          if (_.indexOf(supportedLayout, 'full-width') == -1) {
+            availablePositions.full = false;
+          }
+        }
+
+        this.$('.editor-component-list-sidebar-list').append(new EditorComponentListItemView({
+          model: componentType,
+          availablePositions: availablePositions,
+          _parentId: this.model.get('_parentId'),
+          $parentElement: this.$parentElement,
+          parentView: this.parentView,
+          searchTerms: componentType.get('displayName').toLowerCase()
+        }).$el);
+      }, this);
+    },
+
+    onOverlayClicked: function(event) {
+      if ($(event.target).hasClass('editor-component-list')) {
+        Origin.trigger('editorComponentListView:removeSubviews');
+        $('html').css('overflow-y', '');
+        this.remove();
       }
     },
-    {
-      template: 'editorComponentList'
-    });
+
+    onSearchKeyup: function(event) {
+      var searchValue = $(event.currentTarget).val();
+      Origin.trigger('editorComponentListView:searchKeyup', searchValue);
+    },
+
+    onScreenResize: function(windowWidth, windowHeight) {
+      this.$('.editor-component-list-sidebar-list').height(windowHeight - this.headerHeight);
+    }
+  },
+  {
+    template: 'editorComponentList'
+  });
 
   return EditorComponentListView;
 });

--- a/frontend/src/core/editor/page/views/editorComponentView.js
+++ b/frontend/src/core/editor/page/views/editorComponentView.js
@@ -151,8 +151,8 @@ define(function(require){
       }, this);
 
       var supportedLayout = componentType.get("properties")._supportedLayout;
-      var isFullSupported = _.indexOf(supportedLayout.enum, "full-width") > -1;
-      var isHalfSupported = _.indexOf(supportedLayout.enum, "half-width") > -1;
+      var isFullWidthSupported = _.indexOf(supportedLayout.enum, "full-width") > -1;
+      var isHalfWidthSupported = _.indexOf(supportedLayout.enum, "half-width") > -1;
 
       var movePositions = {
         left: false,
@@ -160,9 +160,9 @@ define(function(require){
         full: false
       };
 
-      if (isHalfSupported) {
+      if (isHalfWidthSupported) {
         var siblings = this.model.getSiblings();
-        var showFull = !siblings.length && isFullSupported;
+        var showFull = !siblings.length && isFullWidthSupported;
         var type = this.model.get('_layout');
 
         switch (type) {

--- a/frontend/src/core/editor/page/views/editorComponentView.js
+++ b/frontend/src/core/editor/page/views/editorComponentView.js
@@ -29,8 +29,8 @@ define(function(require){
 
       this.on('contextMenu:component:edit', this.loadComponentEdit);
       this.on('contextMenu:component:copy', this.onCopy);
-      this.on('contextMenu:component:copyID', this.onCopyID),
-        this.on('contextMenu:component:cut', this.onCut);
+      this.on('contextMenu:component:copyID', this.onCopyID);
+      this.on('contextMenu:component:cut', this.onCut);
       this.on('contextMenu:component:delete', this.deleteComponentPrompt);
     },
 

--- a/frontend/src/core/editor/page/views/editorComponentView.js
+++ b/frontend/src/core/editor/page/views/editorComponentView.js
@@ -30,7 +30,7 @@ define(function(require){
       this.on('contextMenu:component:edit', this.loadComponentEdit);
       this.on('contextMenu:component:copy', this.onCopy);
       this.on('contextMenu:component:copyID', this.onCopyID),
-      this.on('contextMenu:component:cut', this.onCut);
+        this.on('contextMenu:component:cut', this.onCut);
       this.on('contextMenu:component:delete', this.deleteComponentPrompt);
     },
 
@@ -145,28 +145,40 @@ define(function(require){
     },
 
     evaluateLayout: function() {
+
+      var componentType = _.find(Origin.editor.data.componentTypes.models, function(type){
+        return type.get('component') == this.model.get('_component');
+      }, this);
+
+      var supportedLayout = componentType.get("properties")._supportedLayout;
+      var isFullSupported = _.indexOf(supportedLayout.enum, "full-width") > -1;
+      var isHalfSupported = _.indexOf(supportedLayout.enum, "half-width") > -1;
+
       var movePositions = {
         left: false,
         right: false,
         full: false
       };
 
-      var siblings = this.model.getSiblings();
-      var showFull = !siblings.length;
-      var type = this.model.get('_layout');
-      switch (type) {
-        case 'left':
-          movePositions.right = true;
-          movePositions.full = showFull;
-          break;
-        case 'right':
-          movePositions.left = true;
-          movePositions.full = showFull;
-          break;
-        case 'full':
-          movePositions.left = true;
-          movePositions.right = true;
-          break
+      if (isHalfSupported) {
+        var siblings = this.model.getSiblings();
+        var showFull = !siblings.length && isFullSupported;
+        var type = this.model.get('_layout');
+
+        switch (type) {
+          case 'left':
+            movePositions.right = true;
+            movePositions.full = showFull;
+            break;
+          case 'right':
+            movePositions.left = true;
+            movePositions.full = showFull;
+            break;
+          case 'full':
+            movePositions.left = true;
+            movePositions.right = true;
+            break
+        }
       }
 
       this.model.set('_movePositions', movePositions);


### PR DESCRIPTION
_supportedLayout was not working at all meaning left, right and full were always available even if a plugin's properties.schema was limited to `half-width` or `full-width` only. This PR addresses the issue in two areas:

Sidebar component list - when a component is selected only the options specified in the properties schema are available. 
Page editor - if a component is full-width only then the `component-move` arrow icons will not be rendered. If half width only then the full width arrow will not be rendered