### PR TITLE
Added a Scaffold override to allow for specifying 'min’, 'max' values…

### DIFF
--- a/frontend/src/core/scaffold/scaffold.js
+++ b/frontend/src/core/scaffold/scaffold.js
@@ -107,7 +107,7 @@ define(function(require) {
 			_.each(objectSchema, function(field, key) {
 				setupSchemaFields(field, key, objectSchema, scaffoldObjectSchema);
 			});
-			
+
 		} else if (field.type != 'object' || field.inputType) {
 
 			var validators = [];
@@ -129,7 +129,7 @@ define(function(require) {
                 console.log('No validator of that sort - please register: "' + validator + '" by using Origin.scaffold.addCustomValidator(name, validatorMethod)');
               }
               // If match is found - add the method
-              validators.push(customValidator.validatorMethod);  
+              validators.push(customValidator.validatorMethod);
             }
 					}
 				}
@@ -152,12 +152,6 @@ define(function(require) {
 
 			scaffoldSchema[key] = fieldObject;
 
-			var editorAttrs = field.editorAttrs;
-
-			if (editorAttrs) {
-				scaffoldSchema[key].editorAttrs = editorAttrs;
-			}
-			
 		} else {
 
 			scaffoldSchema[key] = {
@@ -174,9 +168,14 @@ define(function(require) {
 
 		}
 
+    var editorAttrs = field.editorAttrs;
+    if (editorAttrs) {
+      scaffoldSchema[key].editorAttrs = editorAttrs;
+    }
+
 		if (field.title) {
 			scaffoldSchema[key].title = field.title;
-			
+
 		} else if (field.type === 'object' || field.type === 'array') {
 			scaffoldSchema[key].title = '';
 			scaffoldSchema[key].legend = field.legend;
@@ -224,7 +223,7 @@ define(function(require) {
 			properties: {
 				legend: 'Properties',
 				fields: []
-			}, 
+			},
 			settings :{
 				legend: 'Settings',
 				fields: []
@@ -274,7 +273,7 @@ define(function(require) {
 		if (!schema._extensions) {
 			delete fieldsets.extensions;
 		}
-		
+
 		// Delete empty field sets
 		if (fieldsets.settings.fields.length === 0) {
 			delete fieldsets.settings;
@@ -324,16 +323,16 @@ define(function(require) {
           schema = _.pick(schema, 'customStyle');
           break;
       }
-      
+
       options.model.schema = buildSchema(schema, options, type);
       options.fieldsets = buildFieldsets(schema, options);
       alternativeModel = options.alternativeModelToSave;
       alternativeAttribute = options.alternativeAttributeToSave;
       currentModel = options.model;
-              
+
       var form = new Backbone.Form(options).render();
       currentForm = form;
-      
+
       return form;
     } catch (e) {
       alert(e.message);

--- a/frontend/src/core/scaffold/scaffold.js
+++ b/frontend/src/core/scaffold/scaffold.js
@@ -149,8 +149,15 @@ define(function(require) {
 			if (_.isObject(field.inputType)) {
 				fieldObject = _.extend(fieldObject, field.inputType);
 			}
+
 			scaffoldSchema[key] = fieldObject;
 
+			var editorAttrs = field.editorAttrs;
+
+			if (editorAttrs) {
+				scaffoldSchema[key].editorAttrs = editorAttrs;
+			}
+			
 		} else {
 
 			scaffoldSchema[key] = {

--- a/frontend/src/core/scaffold/scaffoldOverrides.js
+++ b/frontend/src/core/scaffold/scaffoldOverrides.js
@@ -207,4 +207,38 @@ define(function(require) {
 	    return _.isEmpty(errors) ? null : errors;
 	}
 
+	(function() {
+		var proxied = Backbone.Form.editors.Number.prototype.initialize;
+		
+		Backbone.Form.editors.Number.prototype.initialize = function(options) {
+			proxied.apply(this, arguments);
+
+			if (this.schema) {
+				var step = parseFloat((this.schema.step || (this.schema.editorAttrs && this.schema.editorAttrs.step) || 1));
+				if (!_.isNaN(step) && _.isNumber(step)) {
+					this.$el.attr('step', step);
+				} else {
+					this.$el.attr('step', 'any');
+				}
+
+				if (this.schema.validators) {
+					var rangeValidator = _.findWhere(this.schema.validators, { type: 'range' });
+					if (!rangeValidator) {
+						return;
+					}
+
+					var min = parseInt(rangeValidator.min);
+					if (!_.isNaN(min) && _.isNumber(min)) {
+						this.$el.attr('min', min);
+					}
+
+					var max = parseInt(rangeValidator.max);
+					if (!_.isNaN(max) && _.isNumber(max)) {
+						this.$el.attr('max', max);
+					}
+				}
+			}
+		};
+	}());
+
 });

--- a/frontend/src/core/scaffold/scaffoldOverrides.js
+++ b/frontend/src/core/scaffold/scaffoldOverrides.js
@@ -206,39 +206,4 @@ define(function(require) {
 
 	    return _.isEmpty(errors) ? null : errors;
 	}
-
-	(function() {
-		var proxied = Backbone.Form.editors.Number.prototype.initialize;
-		
-		Backbone.Form.editors.Number.prototype.initialize = function(options) {
-			proxied.apply(this, arguments);
-
-			if (this.schema) {
-				var step = parseFloat((this.schema.step || (this.schema.editorAttrs && this.schema.editorAttrs.step) || 1));
-				if (!_.isNaN(step) && _.isNumber(step)) {
-					this.$el.attr('step', step);
-				} else {
-					this.$el.attr('step', 'any');
-				}
-
-				if (this.schema.validators) {
-					var rangeValidator = _.findWhere(this.schema.validators, { type: 'range' });
-					if (!rangeValidator) {
-						return;
-					}
-
-					var min = parseInt(rangeValidator.min);
-					if (!_.isNaN(min) && _.isNumber(min)) {
-						this.$el.attr('min', min);
-					}
-
-					var max = parseInt(rangeValidator.max);
-					if (!_.isNaN(max) && _.isNumber(max)) {
-						this.$el.attr('max', max);
-					}
-				}
-			}
-		};
-	}());
-
 });

--- a/frontend/src/core/scaffold/scaffoldOverrides.js
+++ b/frontend/src/core/scaffold/scaffoldOverrides.js
@@ -14,8 +14,8 @@ define(function(require) {
 	        <button class="btn btn-primary" type="submit"><%= submitButton %></button>\
 	      <% } %>\
 	    </form>\
-	  ', 
-	  null, 
+	  ',
+	  null,
 	  Backbone.Form.constructor.templateSettings);
 	Backbone.Form.Fieldset.prototype.template = Handlebars.templates['fieldset'];
 	Backbone.Form.Field.prototype.template = Handlebars.templates['field'];
@@ -50,7 +50,7 @@ define(function(require) {
 		//Pretty print the object keys and values
 		var parts = [];
 		_.each(this.nestedSchema, function(schema, key) {
-			
+
 			var desc = schema.title ? schema.title : createTitle(key),
 			val = value[key];
 
@@ -135,14 +135,14 @@ define(function(require) {
 		if (!value && typeof this.schema.default !== 'undefined') {
       value = this.schema.default;
     }
-    
+
     this.$el.val(value);
 	}
 
 	Backbone.Form.editors.TextArea.prototype.getValue = function() {
 		return this.editor.getData().replace(/[\t\n]/g, '');
 	}
-  
+
   Backbone.Form.editors.TextArea.prototype.remove = function() {
     this.editor.removeAllListeners();
     CKEDITOR.remove(this.editor);
@@ -206,4 +206,5 @@ define(function(require) {
 
 	    return _.isEmpty(errors) ? null : errors;
 	}
+
 });


### PR DESCRIPTION
… for Number inputs. 'Step' is also configurable. These values can be supplied in the schema like so:
      
```
{
    "step": 1,
    "validators": [
        {"type": "range", "min": 1, "max": 100}
    ]
}
```
Fixes #1659 