### PR TITLE
Fix auth source issue

### DIFF
--- a/lib/dml/mongoose/index.js
+++ b/lib/dml/mongoose/index.js
@@ -67,11 +67,13 @@ MongooseDB.prototype.connect = function(db) {
   
   // Construct the authentication part of the connection string.
   authenticationString = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
-  
+
+  var connectionString = '';
+
   // Check if a MongoDB replicaset array has been specified.
   if (dbReplicaset && Array.isArray(dbReplicaset) && dbReplicaset.length !== 0) {
     // The replicaset should contain an array of hosts and ports   
-    this.conn = mongoose.createConnection('mongodb://' + authenticationString + dbReplicaset.join(',') + '/' + dbName, options);
+    connectionString = 'mongodb://' + authenticationString + dbReplicaset.join(',') + '/' + dbName
   } else {
     // Get the host and port number from the configuration.
     dbHost = configuration.getConfig('dbHost');  
@@ -79,8 +81,15 @@ MongooseDB.prototype.connect = function(db) {
 
     portString = dbPort ? ':' + dbPort : '';
 
-    this.conn = mongoose.createConnection('mongodb://' + authenticationString + dbHost + portString + '/' + dbName, options);
+    connectionString = 'mongodb://' + authenticationString + dbHost + portString + '/' + dbName;
   }
+
+  var authSource = configuration.getConfig('dbAuthSource');
+  if(typeof authSource === 'string' && authSource !== '' ){
+    connectionString += '?authSource=' + authSource
+  }
+
+  this.conn = mongoose.createConnection(connectionString, options);
  
   this.conn.on('error', logger.log.bind(logger, 'error'));
   this.conn.once('error', function(){ logger.log('error', 'Database Connection failed, please check your database'); }); //added to give console notification of the problem


### PR DESCRIPTION
Fixes: https://github.com/adaptlearning/adapt_authoring/issues/1673

Allows you to set auth source as you do other database configs. `dbAuthSource` is the config attribute.

Docs would need to be updated here https://github.com/adaptlearning/adapt_authoring/wiki/Configuring-the-Authoring-Tool on merge.

