### PR TITLE
Bump timeout for Travis

### DIFF
--- a/test/entry.js
+++ b/test/entry.js
@@ -15,7 +15,7 @@ var testConfig = require('./testConfig.json');
 
 var app = origin();
 
-var EXTENDED_TIMEOUT = 60000;
+var EXTENDED_TIMEOUT = 600000;
 
 before(function(done) {
   this.timeout(EXTENDED_TIMEOUT);


### PR DESCRIPTION
Seems 1 min isn't always enough for the Travis servers to set up/down, so bumping to 10 as before