### PR TITLE
Allows you to run nyc to check mocha test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ version.json
 .vagrant
 .env
 .project
+
+.nyc_output
+coverage

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,12 @@
+{
+  "include": [
+    "lib/*.js",
+    "routes/**/*.js",
+    "plugins/**/*.js",
+    "index.js"
+  ],
+  "reporter": [
+    "text",
+    "text-summary"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "node": "4.x"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "test-coverage": "nyc mocha"
   },
   "dependencies": {
     "archiver": "~0.16.0",
@@ -155,6 +156,7 @@
   "devDependencies": {
     "mocha": "3",
     "mongodb": "^2.2.30",
+    "nyc": "^11.1.0",
     "phantom": "^0.6.5",
     "should": "~11.2.1",
     "supertest": "~0.8.1"


### PR DESCRIPTION
Run `npm run test-coverage` and it will give you an output of the current test coverage.

I set this up the other day out of interest, and it will be useful as part of #1705 