### PR TITLE
Add instruction to component schema

### DIFF
--- a/frontend/src/core/models/componentModel.js
+++ b/frontend/src/core/models/componentModel.js
@@ -26,7 +26,8 @@ define(function(require) {
       'title',
       'version',
       'themeSettings',
-      '_onScreen'
+      '_onScreen',
+      'instruction'
     ]
   });
 

--- a/plugins/content/component/model.schema
+++ b/plugins/content/component/model.schema
@@ -81,6 +81,12 @@
       "validators": [],
       "translatable": true
     },
+    "instruction": {
+      "type": "string",
+      "default" : "",
+      "inputType": "Text",
+      "translatable": true
+    },
     "_onScreen": {
       "type": "object",
       "title": "",


### PR DESCRIPTION
Resolves #1712.

Note: where a plugin's schema hasn't been updated to be instruction-less, it looks like the plugin's field is used, i.e. `Instruction text two` in the screenshot below.

![instruction](https://user-images.githubusercontent.com/922987/29822251-b9bf176e-8cc2-11e7-8210-d72df3f32a9c.png)
