### PR TITLE
article view now generated after article model saved

### DIFF
--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -127,8 +127,6 @@ define(function(require){
         _type:'article'
       });
 
-      var newArticleView = _this.addArticleView(newPageArticleModel);
-
       newPageArticleModel.save(null, {
         error: function() {
           Origin.Notify.alert({
@@ -138,6 +136,7 @@ define(function(require){
         },
         success: function(model, response, options) {
           Origin.editor.data.articles.add(model);
+          var newArticleView = _this.addArticleView(newPageArticleModel);
           newArticleView.$el.removeClass('syncing').addClass('synced');
           newArticleView.addBlock();
         }


### PR DESCRIPTION
Duplicate pr as https://github.com/adaptlearning/adapt_authoring/pull/1771 was somehow merged into master.

Are we happy to leave it as others are also there?