### PR TITLE
Fixes double-rendering of blocks on new article creation

### DIFF
--- a/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
@@ -22,7 +22,9 @@ define(function(require){
     },
 
     postRender: function() {
-      this.addBlockViews();
+      if (!this._skipRender) {
+        this.addBlockViews();
+      }
       this.setupDragDrop();
     },
 

--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -112,6 +112,7 @@ define(function(require){
       }, {
         success: _.bind(function(model, response, options) {
           var articleView = this.addArticleView(model);
+          articleView._skipRender = true; // prevent render of blocks in postRender
           articleView.addBlock();
         }, this),
         error: function() {


### PR DESCRIPTION
not pretty but it solves it for me ...

do not render the blocks when a new article is created. This makes sure the block View is only rendered once the block Model is created.