### PR TITLE
Add colour labels to content

### DIFF
--- a/frontend/src/core/app.js
+++ b/frontend/src/core/app.js
@@ -70,6 +70,7 @@
       'modules/sidebar/index',
       'modules/user/index',
       'modules/userManagement/index',
+      'modules/colorLabel/index',
     ], callback);
   }
 

--- a/frontend/src/core/models/blockModel.js
+++ b/frontend/src/core/models/blockModel.js
@@ -27,8 +27,10 @@ define(function(require) {
       'title',
       '_extensions',
       'themeSettings',
-      '_onScreen'
+      '_onScreen',
+      '_colorLabel'
     ]
+
   });
 
   return BlockModel;

--- a/frontend/src/core/models/componentModel.js
+++ b/frontend/src/core/models/componentModel.js
@@ -26,7 +26,8 @@ define(function(require) {
       'title',
       'version',
       'themeSettings',
-      '_onScreen'
+      '_onScreen',
+      '_colorLabel'
     ]
   });
 

--- a/frontend/src/modules/colorLabel/index.js
+++ b/frontend/src/modules/colorLabel/index.js
@@ -1,0 +1,48 @@
+define([
+    'core/origin',
+    './models/colors',
+    './views/colorLabelPopupView'
+], function(Origin, ColorsModel, ColorLabelPopupView) {
+    
+    'use strict';
+    
+    var parentView;
+    var eventName;
+
+    Origin.on('contextMenu:open', function(view, event) {
+        var type = view.model.get('_type');
+
+        if (parentView) {
+            removeEvent();
+        }
+
+        parentView = view;
+        eventName = 'contextMenu:'+type+':colorLabel';
+        
+        setupEvent();
+    });
+
+    Origin.on('contextMenu:closed', function() {
+        removeEvent();
+    });
+
+    function setupEvent() {
+        parentView.on(eventName, showPopup);
+    }
+
+    function removeEvent() {
+        if (!parentView) return;
+
+        parentView.off(eventName, showPopup);
+        parentView = null;
+        eventName = '';
+    }
+
+    function showPopup() {
+        (new ColorLabelPopupView({
+            model: new ColorsModel(),
+            parentView: parentView
+        })).$el.appendTo(document.body);
+    }
+
+});

--- a/frontend/src/modules/colorLabel/less/colorLabels.less
+++ b/frontend/src/modules/colorLabel/less/colorLabels.less
@@ -1,0 +1,51 @@
+.colorlabel {
+    @popup-border-color: silver;
+
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%,-50%);
+
+    background: @adapt-white;
+    border: solid 1px @popup-border-color;
+    box-shadow: 0 0 4px @popup-border-color;
+
+    .colorlabel-inner {
+        padding: 60px 40px;
+    }
+
+    .colors {
+        .colors-inner {
+
+            padding-bottom: 20px;
+
+            .color-item {
+
+                float: left;
+                font-size: 0;
+                border: solid 4px @adapt-white;
+
+                div {
+                    border: solid 1px @adapt-white;
+                    width: 30px;
+                    height: 30px;
+                    border-radius: 4px;
+                }
+
+                &.selected {
+                    border-color: darken(@adapt-white, 50%);
+                    background-color: darken(@adapt-white, 50%);
+                    border-radius: 8px;
+                }
+            }
+        }
+    }
+
+    .footer {
+        text-align: center;
+
+        .warning {
+            margin-right: 40px;
+        }
+    }
+}

--- a/frontend/src/modules/colorLabel/models/colors.js
+++ b/frontend/src/modules/colorLabel/models/colors.js
@@ -1,0 +1,54 @@
+define([
+    'core/origin'
+], function(Origin) {
+    
+    'use strict';
+
+    var DefaultColors = Backbone.Model.extend({
+
+        defaults: {
+            // colors from https://material.io/guidelines/style/color.html#color-color-palette
+            colors: [
+                // Grey
+                { background: "#F5F5F5", border: "#9E9E9E" },
+                { background: "#E0E0E0", border: "#757575" },
+                // red
+                { background: "#FFEBEE", border: "#F44336" },
+                { background: "#EF9A9A", border: "#E53935" },
+                // purple
+                { background: "#E1BEE7", border: "#9C27B0" },
+                { background: "#CE93D8", border: "#8E24AA" },
+                // blue
+                { background: "#E3F2FD", border: "#42A5F5" },
+                { background: "#90CAF9", border: "#1976D2" },
+                // green 
+                { background: "#E8F5E9", border: "#4CAF50" },
+                { background: "#C8E6C9", border: "#43A047" },
+                // orange
+                { background: "#FFE0B2", border: "#FF9800" },
+                { background: "#FFCC80", border: "#FB8C00" },
+                
+                // Deep Orange
+                { background: "#FFCCBC", border: "#FF5722" },
+                { background: "#FFAB91", border: "#F4511E" },
+                // Brown
+                { background: "#D7CCC8", border: "#795548" },
+                { background: "#BCAAA4", border: "#6D4C41" }
+            ]
+        },
+
+        findByColor: function(background) {
+            var colors = this.get('colors');
+            for (var i = 0; i < colors.length; i++) {
+                if (colors[i].background === background) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+    });
+
+    return DefaultColors;
+
+});

--- a/frontend/src/modules/colorLabel/templates/colorLabelPopUpView.hbs
+++ b/frontend/src/modules/colorLabel/templates/colorLabelPopUpView.hbs
@@ -1,0 +1,18 @@
+<div class="colorlabel-inner">
+    <div class="colors">
+        <div class="colors-inner clearfix">
+            {{#each colors}}
+                <div class="color-item" data-item={{@index}}>
+                    <div style="background-color:{{background}};border-color:{{border}}"></div>
+                </div>
+            {{/each}}
+        </div>
+    </div>
+    <div class="footer">
+        <div class="footer-inner">
+            <button class="btn warning reset">Reset</button>
+            <button class="btn primary apply">Apply</button>
+            <button class="btn secondary cancel">Cancel</button>
+        </div>
+    </div>
+</div>

--- a/frontend/src/modules/colorLabel/views/colorLabelPopupView.js
+++ b/frontend/src/modules/colorLabel/views/colorLabelPopupView.js
@@ -1,0 +1,110 @@
+define([
+    'core/origin',
+    'core/views/originView'
+], function(Origin, OriginView) {
+
+    var ColorLabelPopUpView = OriginView.extend({
+
+        className: 'colorlabel',
+
+        events: {
+            'click .reset': 'onReset',
+            'click .apply': 'onApply',
+            'click .cancel': 'remove',
+            'click .color-item': 'onItemClick'
+        },
+
+        initialize: function(options) {
+            this.parentView = options.parentView;
+            OriginView.prototype.initialize.apply(this, arguments);
+        },
+
+        onItemClick: function(event) {
+            var $elm = $(event.currentTarget);
+            var index = $elm.data('item');
+
+            this.selected = index;
+            this.updateClasses();
+        },
+
+        updateClasses: function() {
+            this.$('.color-item').removeClass('selected').eq(this.selected).addClass('selected');
+        },
+
+        onReset: function() {
+            var model = this.parentView.model;
+            this.selected = -1;
+
+            model.save('_colorLabel', {}, {
+                patch: true,
+                success: _.bind(this.onSuccess, this),
+                error: _.bind(this.onError, this)
+            });
+        },
+
+        onApply: function(event) {
+            if (this.selected === -1) return;
+            this.addItem();
+        },
+
+        preRender: function() {
+            this.selected = -1;
+        },
+
+        postRender: function() {
+            if (!this.parentView.model.has('_colorLabel')) return;
+
+            var color = this.parentView.model.get('_colorLabel');
+            var index = this.model.findByColor(color.background);
+            if (index !== -1) {
+                this.selected = index;
+                this.updateClasses();
+            }
+        },
+
+        applyOnParent: function() {
+            var color = this.model.get('colors')[this.selected];
+            var bg = 'inherit';
+            var border = 'inherit';
+
+            if (this.selected !== -1) {
+                this.parentView.$el.css({
+                    'backgroundColor': color.background,
+                    'borderColor': color.border
+                });
+            } else {
+                this.parentView.el.removeAttribute('style');
+            }
+        },
+
+        addItem: function() {
+            var model = this.parentView.model;
+            var color = this.model.get('colors')[this.selected];
+
+            model.save('_colorLabel', {
+                'background': color.background,
+                'border': color.border
+            }, {
+                patch: false,
+                success: _.bind(this.onSuccess, this),
+                error: _.bind(this.onError, this)
+            });
+        },
+
+        onSuccess: function() {
+            this.applyOnParent()
+            this.remove();
+        },
+
+        onError: function(model, response, options) {
+            this.remove();
+            alert(response);
+        }
+
+    }, {
+        template: 'colorLabelPopUpView'
+    });
+
+    return ColorLabelPopUpView;
+
+});

--- a/frontend/src/modules/contextMenu/index.js
+++ b/frontend/src/modules/contextMenu/index.js
@@ -40,7 +40,7 @@ define(function(require) {
     ContextMenu.addItem('component', getDefaultItems());
     ContextMenu.addItem('page', getDefaultItems());
     ContextMenu.addItem('menu', getDefaultItems(['copy']));
-    ContextMenu.addItem('page-min', getDefaultItems(['copy','delete']));
+    ContextMenu.addItem('page-min', getDefaultItems(['copy','delete','colorLabel']));
     ContextMenu.addItem('sharedcourse', [
       {
         title: Origin.l10n.t('app.duplicate'),
@@ -53,7 +53,7 @@ define(function(require) {
         callbackEvent: 'preview'
       }
     ]);
-    ContextMenu.addItem('course', getDefaultItems());
+    ContextMenu.addItem('course', getDefaultItems(['colorLabel']));
   };
 
   /*
@@ -80,6 +80,11 @@ define(function(require) {
         title: Origin.l10n.t('app.delete'),
         className: 'context-menu-item',
         callbackEvent: "delete"
+      },
+      {
+        title: 'Color Label',
+        className: 'context-menu-item',
+        callbackEvent: "colorLabel"
       }
     ];
     if(!blacklist) {

--- a/frontend/src/modules/editor/article/views/editorArticleEditView.js
+++ b/frontend/src/modules/editor/article/views/editorArticleEditView.js
@@ -11,7 +11,13 @@ define(function(require) {
     preRender: function() {
       this.listenTo(Origin, 'editorArticleEditSidebar:views:save', this.save);
       this.model.set('ancestors', this.model.getPossibleAncestors().toJSON());
+    },
+
+    applyColorLabels: function() {
+      // overwrite defaults from EditorOriginView
+      return;
     }
+
   }, {
     template: 'editorArticleEdit'
   });

--- a/frontend/src/modules/editor/block/views/editorBlockEditView.js
+++ b/frontend/src/modules/editor/block/views/editorBlockEditView.js
@@ -11,7 +11,13 @@ define(function(require) {
     preRender: function() {
       this.listenTo(Origin, 'editorBlockEditSidebar:views:save', this.save);
       this.model.set('ancestors', this.model.getPossibleAncestors().toJSON());
+    },
+
+    applyColorLabels: function() {
+      // overwrite defaults from EditorOriginView
+      return;
     }
+
   }, {
     template: 'editorBlockEdit'
   });

--- a/frontend/src/modules/editor/component/views/editorComponentEditView.js
+++ b/frontend/src/modules/editor/component/views/editorComponentEditView.js
@@ -16,7 +16,13 @@ define(function(require) {
     cancel: function (event) {
       event && event.preventDefault();
       Origin.trigger('editorSidebarView:removeEditView', this.model);
+    },
+
+    applyColorLabels: function() {
+      // overwrite defaults from EditorOriginView
+      return;
     }
+
   }, {
     template: 'editorComponentEdit'
   });

--- a/frontend/src/modules/editor/contentObject/less/editorMenuItem.less
+++ b/frontend/src/modules/editor/contentObject/less/editorMenuItem.less
@@ -6,12 +6,13 @@ a.open-context-contentObject {
     position: relative;
     display: block;
     margin: 20px;
+    background-color: #fff;
+    border: solid 1px #d3e2e5;
 
     &-inner {
         overflow:hidden;
         border-radius:3px;
         position: relative;
-        background-color: #fff;
         cursor: pointer;
         padding: 30px 20px 10px;
         transition:background-color 0.3s;

--- a/frontend/src/modules/editor/contentObject/templates/editorPage.hbs
+++ b/frontend/src/modules/editor/contentObject/templates/editorPage.hbs
@@ -1,5 +1,5 @@
 <div class="page-inner">
-  <div class="page-detail">
+  <div class="page-detail" style="{{_colorLabelStyle}}">
     <h4 class="page-name title">
       <a href="#" class="page-edit-button" title="{{t 'app.clicktoedit'}}"><i class="fa fa-cog fa-fw"></i></a>
       {{#if displayTitle}}{{displayTitle}}{{else}}{{title}}{{/if}}

--- a/frontend/src/modules/editor/contentObject/views/editorPageEditView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageEditView.js
@@ -10,7 +10,13 @@ define(function(require) {
 
     preRender: function() {
       this.listenTo(Origin, 'editorPageEditSidebar:views:save', this.save);
+    },
+
+    applyColorLabels: function() {
+      // overwrite defaults from EditorOriginView
+      return;
     }
+
   }, {
     template: 'editorPageEdit'
   });

--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -127,8 +127,6 @@ define(function(require){
         _type:'article'
       });
 
-      var newArticleView = _this.addArticleView(newPageArticleModel);
-
       newPageArticleModel.save(null, {
         error: function() {
           Origin.Notify.alert({
@@ -138,6 +136,7 @@ define(function(require){
         },
         success: function(model, response, options) {
           Origin.editor.data.articles.add(model);
+          var newArticleView = _this.addArticleView(newPageArticleModel);
           newArticleView.$el.removeClass('syncing').addClass('synced');
           newArticleView.addBlock();
         }

--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -168,7 +168,14 @@ define(function(require){
     onCutArticle: function(view) {
       this.once('pageView:postRender', view.showPasteZones);
       this.render();
+    },
+
+    applyColorLabels: function() {
+      // overwrite defaults from EditorOriginView
+      if (!this.model || !this.model.has('_colorLabel')) return;
+      this.model.set('_colorLabelStyle', this.generateColorLabelStyles());
     }
+
   }, {
     template: 'editorPage'
   });

--- a/frontend/src/modules/editor/global/views/editorOriginView.js
+++ b/frontend/src/modules/editor/global/views/editorOriginView.js
@@ -5,6 +5,28 @@ define(function(require){
   var Helpers = require('core/helpers');
 
   var EditorOriginView = OriginView.extend({
+
+    attributes: function() {
+      var attr = {};
+      if (this.model && this.model.has('_id')) {
+        attr['data-adapt-id'] = this.model.get('_id');
+      }
+      
+      if (this.model && this.model.has('_colorLabel')) {
+        var colorLabel = this.model.get('_colorLabel');
+        var colors = [];
+
+        if (colorLabel.background) {
+          colors.push('background-color:'+colorLabel.background);
+        }
+        if (colorLabel.border) {
+          colors.push('border-color:'+colorLabel.border);
+        }
+        attr['style'] = colors.join(';');
+      }
+      return attr;
+    },
+
     events: {
       'click .paste-cancel': 'onPasteCancel',
       'click .field-object .legend': 'onFieldObjectClicked'

--- a/frontend/src/modules/editor/global/views/editorOriginView.js
+++ b/frontend/src/modules/editor/global/views/editorOriginView.js
@@ -11,19 +11,6 @@ define(function(require){
       if (this.model && this.model.has('_id')) {
         attr['data-adapt-id'] = this.model.get('_id');
       }
-      
-      if (this.model && this.model.has('_colorLabel')) {
-        var colorLabel = this.model.get('_colorLabel');
-        var colors = [];
-
-        if (colorLabel.background) {
-          colors.push('background-color:'+colorLabel.background);
-        }
-        if (colorLabel.border) {
-          colors.push('border-color:'+colorLabel.border);
-        }
-        attr['style'] = colors.join(';');
-      }
       return attr;
     },
 
@@ -38,6 +25,7 @@ define(function(require){
         this.form = options.form;
         this.filters = [];
       }
+      this.applyColorLabels();
       OriginView.prototype.initialize.apply(this, arguments);
 
       this.listenTo(Origin, {
@@ -239,7 +227,27 @@ define(function(require){
       Origin.Notify.alert({ type: 'error', title: title, text: text });
 
       Origin.trigger('sidebar:resetButtons');
+    },
+
+    generateColorLabelStyles: function() {
+      var colorLabel = this.model.get('_colorLabel');
+      var colors = [];
+
+      if (colorLabel.background) {
+        colors.push('background-color:'+colorLabel.background);
+      }
+      if (colorLabel.border) {
+        colors.push('border-color:'+colorLabel.border);
+      }
+
+      return colors.join(';');
+    },
+
+    applyColorLabels: function() {
+      if (!this.model || !this.model.has('_colorLabel')) return;
+      this.el.style = this.generateColorLabelStyles();
     }
+
   });
 
   return EditorOriginView;

--- a/lib/dml/schema/system/content.schema
+++ b/lib/dml/schema/system/content.schema
@@ -25,6 +25,11 @@
       "required": true,
       "default": 1,
       "editorOnly": true
+    },
+    "_colorLabel": {
+      "type": "object",
+      "required": false,
+      "editorOnly": true
     }
   }
 }


### PR DESCRIPTION
resolves #1785 

Adds ability to set background colors for elements in page and menuEditor. Right now the colors are stored in a model. Therefore, user defined colors are not yet supported. 

I took the colors from google Material-Design Docs. Feel free to suggest colors :)

![image](https://user-images.githubusercontent.com/11990374/36418135-3590797e-162e-11e8-9dd3-6ee31c5a0880.png)

If you set a color-label for a Page, it also applies this color to the background-color in the pageEditor. That's because bot view's extend from the same base view. To me this is not an issue, as it actually improves UX by showing "I am currently working on the redish page I just entered.". I do however understand if the color is a bit to much and I am happy to change this.

![image](https://user-images.githubusercontent.com/11990374/36418177-6022dbdc-162e-11e8-8fe2-3e1fbb73cb9c.png)
![image](https://user-images.githubusercontent.com/11990374/36418630-b613de78-162f-11e8-9572-1f88b4643f65.png)
