### PR TITLE
Allow MongoDB authentication in install script

### DIFF
--- a/install.js
+++ b/install.js
@@ -80,6 +80,27 @@ installHelpers.getLatestFrameworkVersion(function(error, latestFrameworkTag) {
         default: 27017
       },
       {
+        name: 'dbUser',
+        type: 'string',
+        description: 'Database server user',
+        pattern: installHelpers.inputHelpers.alphanumValidator,
+        default: ''
+      },
+      {
+        name: 'dbPass',
+        type: 'string',
+        description: 'Database server password',
+        pattern: installHelpers.inputHelpers.alphanumValidator,
+        default: ''
+      },
+      {
+        name: 'dbAuthSource',
+        type: 'string',
+        description: 'Database server authentication database',
+        pattern: installHelpers.inputHelpers.alphanumValidator,
+        default: 'admin'
+      },
+      {
         name: 'dataRoot',
         type: 'string',
         description: 'Data directory path',


### PR DESCRIPTION
Resubmitted from https://github.com/adaptlearning/adapt_authoring/pull/1822 because of merge issues.

Fixes #1903 