### PR TITLE
Migrations can be created and are ran during upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /conf/config.json
-
+/conf/migrate.json
 /data
 
 /frontend/build

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,6 +234,38 @@ module.exports = function(grunt) {
     return config.serverPort;
   };
 
+  grunt.registerTask('migration-conf', 'Creating migration Conf', function() {
+    var config = grunt.file.readJSON('conf/config.json');
+    var connectionString = '';
+
+    // Construct the authentication part of the connection string.
+    var authenticationString = config.dbUser && config.dbPass ? config.dbUser + ':' + config.dbPass + '@' : '';
+
+    // Check if a MongoDB replicaset array has been specified.
+    if (config.dbReplicaset && Array.isArray(config.dbReplicaset) && config.dbReplicaset.length !== 0) {
+      // The replicaset should contain an array of hosts and ports
+      connectionString = 'mongodb://' + authenticationString + config.dbReplicaset.join(',') + '/' + config.dbName
+    } else {
+      // Get the host and port number from the configuration.
+
+      var portString = config.dbPort ? ':' + config.dbPort : '';
+
+      connectionString = 'mongodb://' + authenticationString + config.dbHost + portString + '/' + config.dbName;
+    }
+    if(typeof config.authSource === 'string' && config.authSource !== '' ){
+      connectionString += '?authSource=' + config.authSource
+    }
+
+    var migrateConf = {
+      migrationsDir : 'migrations/lib',
+      es6 : false,
+      dbConnectionUri: connectionString
+    };
+
+    grunt.file.write('conf/migrate.json', JSON.stringify(migrateConf, null, 2));
+
+  });
+
   /**
   * Accepts 'build' and 'prod' params
   * e.g. grunt build:prod
@@ -251,7 +283,7 @@ module.exports = function(grunt) {
     grunt.file.write(configFile, JSON.stringify(config, null, 2));
     // run the tasks
     var compilation = (config.isProduction) ? 'compile' : 'dev';
-    grunt.task.run(['requireBundle', 'merge-json', 'copy', 'less:' + compilation, 'handlebars', 'requirejs:'+ compilation]);
+    grunt.task.run(['migration-conf', 'requireBundle', 'merge-json', 'copy', 'less:' + compilation, 'handlebars', 'requirejs:'+ compilation]);
   });
 
   grunt.registerTask('server', "Running Server", function() {

--- a/install.js
+++ b/install.js
@@ -296,7 +296,8 @@ function start() {
       configureMasterTenant,
       createMasterTenant,
       createSuperUser,
-      buildFrontend
+      buildFrontend,
+      syncMigrations
     ], function(error, results) {
       if(error) {
         console.error('ERROR: ', error);
@@ -495,6 +496,19 @@ function buildFrontend(callback) {
       return callback(`Failed to build the web application, (${error}) \nInstall will continue. Try again after installation completes using 'grunt build:prod'.`);
     }
     callback();
+  });
+}
+
+//As this is a fresh install we dont need to run the migrations so add them to the db and set them to up
+function syncMigrations(callback) {
+  installHelpers.syncMigrations(function(err, migrations){
+    database.getDatabase(function(err, db) {
+      if(err){
+        return callback(err)
+      }
+
+      db.update('migration', {}, {'state': 'up'}, callback)
+    }, masterTenant._id)
   });
 }
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -366,6 +366,10 @@ Origin.prototype.startServer = function (options) {
     });
   };
   _checkForUpdates(function(err, result) {
+    if(err) {
+      logger.log('error', `Check for updates failed, ${err}`);
+    }
+
     // configure server
     var serverOptions = {
       minimal: !app.configuration || !app.configuration.getConfig('dbName')

--- a/lib/dml/schema/system/migration.schema
+++ b/lib/dml/schema/system/migration.schema
@@ -1,0 +1,18 @@
+{
+  "type":"object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "http://jsonschema.net",
+  "$ref": "http://localhost/system/tenantObject.schema",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "date",
+      "required": false
+    },
+    "state": {
+      "type": "string"
+    }
+  }
+}

--- a/lib/installHelpers.js
+++ b/lib/installHelpers.js
@@ -9,6 +9,7 @@ var prompt = require('prompt');
 var readline = require('readline');
 var request = require('request');
 var semver = require('semver');
+var migrateMongoose = require('migrate-mongoose');
 
 var configuration = require('./configuration');
 var pkg = fs.readJSONSync(path.join(__dirname, '..', 'package.json'));
@@ -54,6 +55,8 @@ var exports = module.exports = {
   getInstalledVersions,
   getLatestVersions,
   getUpdateData,
+  getMigrationConfig,
+  syncMigrations,
   installFramework,
   updateFramework,
   updateFrameworkPlugins,
@@ -181,6 +184,35 @@ function getUpdateData(callback) {
 
 function getFrameworkRoot() {
   return path.join(configuration.serverRoot, 'temp', configuration.getConfig('masterTenantID'), 'adapt_framework');
+}
+
+function getMigrationConfig(callback) {
+  var confPath = path.join(configuration.serverRoot, 'conf', 'migrate.json');
+  fs.readJson(confPath, callback);
+}
+
+/**
+ * Adds all migrations to the DB in a down state
+ * @param callback
+ */
+function syncMigrations(callback) {
+  getMigrationConfig(function(err, config) {
+    if(err){
+      return callback(err)
+    }
+
+    var migrator = new migrateMongoose({
+      migrationsPath: config.migrationsDir,
+      dbConnectionUri: config.dbConnectionUri,
+      autosync: true
+    });
+
+    migrator.sync()
+      .then(
+        function(value) { return callback(null, value) },
+        function(reason) { return callback(reason); }
+      )
+  });
 }
 
 /**

--- a/migrations/helpers/helper.js
+++ b/migrations/helpers/helper.js
@@ -1,0 +1,4 @@
+//add any helper methods that all migrations can use here
+module.exports = {
+
+};

--- a/migrations/helpers/template.js
+++ b/migrations/helpers/template.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var database = require('./../../lib/database');
+var helpers = require('./../../migrations/helpers/helper');
+var configuration = require('./../../lib/configuration');
+
+exports.up = function up (done) {
+  database.getDatabase(function(err, db) {
+    if(err){
+      done(err)
+    }
+
+    //DO up migration here
+
+    return done()
+  }, configuration.getConfig('masterTenantID'))
+};
+
+exports.down = function down(done) {
+  database.getDatabase(function(err, db) {
+    if(err){
+      done(err)
+    }
+
+    //DO down migration here
+
+    return done()
+  }, configuration.getConfig('masterTenantID'))
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "node": "4.x"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "migrate": "migrate --config conf/migrate.json --template-file migrations/helpers/template.js"
   },
   "contributors": [
     "Ryan Adams <ryana@learningpool.com>",
@@ -79,6 +80,7 @@
     "log-update": "^2.1.0",
     "matchdep": "~0.3.0",
     "method-override": "^2.3.5",
+    "migrate-mongoose": "^3.2.2",
     "mime": "1.2.x",
     "mkdirp": "0.3.5",
     "moment": "^2.9.0",

--- a/upgrade.js
+++ b/upgrade.js
@@ -5,6 +5,7 @@ var fs = require('fs-extra');
 var optimist = require('optimist');
 var path = require('path');
 var semver = require('semver');
+var migrateMongoose = require('migrate-mongoose');
 
 var configuration = require('./lib/configuration');
 var logger = require('./lib/logger');
@@ -160,6 +161,58 @@ function doUpdate(data) {
         cb();
       });
     },
+    function runMigrations(callback) {
+      installHelpers.syncMigrations(function(err, migrations) {
+        if(err){
+          return callback(err);
+        }
+
+        installHelpers.getMigrationConfig(function(err, config) {
+          if(err){
+            return callback(err);
+          }
+
+          var migrator = new migrateMongoose({
+            migrationsPath: config.migrationsDir,
+            dbConnectionUri: config.dbConnectionUri,
+            autosync: true
+          });
+
+          migrator.list().then(
+            function(migrations) {
+              var migrationsRan = 0;
+              async.everySeries(migrations, function(migration, callback) {
+                if(migration.state === 'up'){
+                  return callback();
+                }
+
+                console.log(`Running ${migration.name} migration`);
+                migrationsRan += 1;
+                migrator.run('up', migration.name).then(
+                  function(value) { return callback(); },
+                  function(reason) { return callback(reason); }
+                )
+
+              }, function(err, data) {
+                if(err){
+                  return callback(err);
+                }
+
+                if(migrationsRan === 1) {
+                  console.log(`1 Migration ran successfully`);
+                } else if(migrationsRan > 1) {
+                  console.log(`${migrationsRan} Migrations ran successfully`);
+                } else {
+                  console.log(`No migrations to run`);
+                }
+                return callback();
+              });
+            },
+            function(reason) { return callback(reason); }
+          )
+        });
+      })
+    }
   ], function(error) {
     if(error) {
       console.error('ERROR:', error);


### PR DESCRIPTION
## Migrations
Migration files are simple they export a down and an up function. Up should make the changes you want and return the callback. Down should revert changes made by up if possible, this allows easier testing and downgrading of a release if needed.

The migration library works by looking in a folder for migration files and comparing the files there to a DB table where it stores the ran state. Any migrations that have not been run will have a state of down and it will run them. 

The migration lib needs a DB connection string because every install can be different its easiest to generate this into a config file for it. I've done this on grunt build that way if someone updates the DB details they just need to run grunt build.

Migrations are not run on install but any new ones will run on upgrade. On install, we need to add any existing ones and mark them as done.

Unfortunately, the release where we add this we cant run migrations because each release uses the last release's upgrade file so it would be good to get this in asap.

### To create a migration
To create a migration you can run `npm run migration create <name>`. This will create a new file from the template in `migrations/libs`. 

### To run a migration from the command line (to test)
To create a migration you can run `npm run migration up <name>`,  `npm run migration down <name>` will revert it.

Fixes #1937