### PR TITLE
Add new config `dbConnectionUri`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,6 @@
+
+var mongoUri = require('mongodb-uri');
+
 // LICENCE https://github.com/adaptlearning/adapt_authoring/blob/master/LICENSE
 module.exports = function(grunt) {
   require('matchdep').filterAll('grunt-*').forEach(grunt.loadNpmTasks);
@@ -239,22 +242,26 @@ module.exports = function(grunt) {
     var config = grunt.file.readJSON('conf/config.json');
     var connectionString = '';
 
-    // Construct the authentication part of the connection string.
-    var authenticationString = config.dbUser && config.dbPass ? config.dbUser + ':' + config.dbPass + '@' : '';
-
-    // Check if a MongoDB replicaset array has been specified.
-    if (config.dbReplicaset && Array.isArray(config.dbReplicaset) && config.dbReplicaset.length !== 0) {
-      // The replicaset should contain an array of hosts and ports
-      connectionString = 'mongodb://' + authenticationString + config.dbReplicaset.join(',') + '/' + config.dbName
+    if (config.dbConnectionUri) {
+      connectionString = config.dbConnectionUri
     } else {
-      // Get the host and port number from the configuration.
+      // Construct the authentication part of the connection string.
+      var authenticationString = config.dbUser && config.dbPass ? config.dbUser + ':' + config.dbPass + '@' : '';
 
-      var portString = config.dbPort ? ':' + config.dbPort : '';
+      // Check if a MongoDB replicaset array has been specified.
+      if (config.dbReplicaset && Array.isArray(config.dbReplicaset) && config.dbReplicaset.length !== 0) {
+        // The replicaset should contain an array of hosts and ports
+        connectionString = 'mongodb://' + authenticationString + config.dbReplicaset.join(',') + '/' + config.dbName
+      } else {
+        // Get the host and port number from the configuration.
 
-      connectionString = 'mongodb://' + authenticationString + config.dbHost + portString + '/' + config.dbName;
-    }
-    if(typeof config.authSource === 'string' && config.authSource !== '' ){
-      connectionString += '?authSource=' + config.authSource
+        var portString = config.dbPort ? ':' + config.dbPort : '';
+
+        connectionString = 'mongodb://' + authenticationString + config.dbHost + portString + '/' + config.dbName;
+      }
+      if(typeof config.authSource === 'string' && config.authSource !== '' ){
+        connectionString += '?authSource=' + config.authSource
+      }
     }
 
     var migrateConf = {

--- a/lib/dml/mongoose/index.js
+++ b/lib/dml/mongoose/index.js
@@ -6,7 +6,8 @@ var Database = require('../../database').Database,
     util = require('util'),
     fs = require('fs'),
     path = require('path'),
-    mongoose = require('mongoose');
+    mongoose = require('mongoose'),
+    mongoUri = require('mongodb-uri');
     _ = require('underscore');
 
 mongoose.Promise = global.Promise;
@@ -56,40 +57,50 @@ MongooseDB.prototype.connect = function(db) {
   if ('object' === typeof db) {
     // We are using a tenant object.
     dbName = db.dbName;
-  } else { 
+  } else {
     // We're on the master tenant.
     dbName = configuration.getConfig('dbName');
   }
-  
-  // Retrieve the user credentials and options.
-  dbUser = configuration.getConfig('dbUser');
-  dbPass = configuration.getConfig('dbPass');
-  dbReplicaset = configuration.getConfig('dbReplicaset');
-  options = configuration.getConfig('dbOptions') || {};
-  options.domainsEnabled = true;
-
-  // Construct the authentication part of the connection string.
-  authenticationString = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
 
   var connectionString = '';
+  var dbConnectionUri = configuration.getConfig('dbConnectionUri');
 
-  // Check if a MongoDB replicaset array has been specified.
-  if (dbReplicaset && Array.isArray(dbReplicaset) && dbReplicaset.length !== 0) {
-    // The replicaset should contain an array of hosts and ports   
-    connectionString = 'mongodb://' + authenticationString + dbReplicaset.join(',') + '/' + dbName
+  if (dbConnectionUri) {
+    // We should replace `dbName` in the connection string
+    var dbConnectionUriParsed = mongoUri.parse(dbConnectionUri)
+    dbConnectionUriParsed.database = dbName
+    connectionString = mongoUri.format(dbConnectionUriParsed)
   } else {
-    // Get the host and port number from the configuration.
-    dbHost = configuration.getConfig('dbHost');  
-    dbPort = configuration.getConfig('dbPort'); 
+    // Retrieve the user credentials and options.
+    dbUser = configuration.getConfig('dbUser');
+    dbPass = configuration.getConfig('dbPass');
+    dbReplicaset = configuration.getConfig('dbReplicaset');
+    options = configuration.getConfig('dbOptions') || {};
+    options.domainsEnabled = true;
 
-    portString = dbPort ? ':' + dbPort : '';
+    // Construct the authentication part of the connection string.
+    authenticationString = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
 
-    connectionString = 'mongodb://' + authenticationString + dbHost + portString + '/' + dbName;
-  }
+    connectionString = '';
 
-  var authSource = configuration.getConfig('dbAuthSource');
-  if(typeof authSource === 'string' && authSource !== '' ){
-    connectionString += '?authSource=' + authSource
+    // Check if a MongoDB replicaset array has been specified.
+    if (dbReplicaset && Array.isArray(dbReplicaset) && dbReplicaset.length !== 0) {
+      // The replicaset should contain an array of hosts and ports
+      connectionString = 'mongodb://' + authenticationString + dbReplicaset.join(',') + '/' + dbName
+    } else {
+      // Get the host and port number from the configuration.
+      dbHost = configuration.getConfig('dbHost');
+      dbPort = configuration.getConfig('dbPort');
+
+      portString = dbPort ? ':' + dbPort : '';
+
+      connectionString = 'mongodb://' + authenticationString + dbHost + portString + '/' + dbName;
+    }
+
+    var authSource = configuration.getConfig('dbAuthSource');
+    if(typeof authSource === 'string' && authSource !== '' ){
+      connectionString += '?authSource=' + authSource
+    }
   }
 
   return mongoose.createConnection(connectionString, options).then(function(conn) {

--- a/lib/dml/mongoose/index.js
+++ b/lib/dml/mongoose/index.js
@@ -62,6 +62,9 @@ MongooseDB.prototype.connect = function(db) {
     dbName = configuration.getConfig('dbName');
   }
 
+  options = configuration.getConfig('dbOptions') || {};
+  options.domainsEnabled = true;
+
   var connectionString = '';
   var dbConnectionUri = configuration.getConfig('dbConnectionUri');
 
@@ -75,8 +78,6 @@ MongooseDB.prototype.connect = function(db) {
     dbUser = configuration.getConfig('dbUser');
     dbPass = configuration.getConfig('dbPass');
     dbReplicaset = configuration.getConfig('dbReplicaset');
-    options = configuration.getConfig('dbOptions') || {};
-    options.domainsEnabled = true;
 
     // Construct the authentication part of the connection string.
     authenticationString = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
@@ -494,10 +495,10 @@ MongooseDB.prototype.addSchema = function (modelName, schema) {
   schema.options.toJSON = {
     transform: function (doc, json, options) {
       Object.keys(rawSchema).forEach(function (key) {
-        if (options && options.forExport && (rawSchema[key].editorOnly 
-          || (Array.isArray(rawSchema[key]) && rawSchema[key].length == 1 && rawSchema[key][0].editorOnly) 
+        if (options && options.forExport && (rawSchema[key].editorOnly
+          || (Array.isArray(rawSchema[key]) && rawSchema[key].length == 1 && rawSchema[key][0].editorOnly)
           && json.hasOwnProperty(key))) {
-          delete json[key];  
+          delete json[key];
         }
 
         if (rawSchema[key].protect && json.hasOwnProperty(key)) {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "migrate-mongoose": "^3.2.2",
     "mime": "^2.3.1",
     "moment": "^2.22.1",
+    "mongodb-uri": "^0.9.7",
     "mongoose": "^5.1.1",
     "morgan": "^1.9.0",
     "multer": "^1.3.0",


### PR DESCRIPTION
It will allow developer to specific himself the whole "connection string". Indeed, there are some case that are not covered by the config, simple example: `ssl=true` that could be append to the query of the string.
I don't think adding a new config key for each case is a good idea.

A new dependency has been introduced `mongodb-uri`. Indeed, in case where `connect(db)` with a db, we need to change the database name in the connection string.

Related #1978