### PR TITLE
double scrollbar fix

### DIFF
--- a/frontend/src/modules/contentPane/less/contentPane.less
+++ b/frontend/src/modules/contentPane/less/contentPane.less
@@ -1,4 +1,4 @@
 .contentPane {
   position: relative;
-  overflow-y: scroll;
+  overflow-y: auto;
 }

--- a/frontend/src/modules/contentPane/less/contentPane.less
+++ b/frontend/src/modules/contentPane/less/contentPane.less
@@ -1,4 +1,4 @@
 .contentPane {
   position: relative;
-  overflow-y: auto;
+  overflow-y: scroll;
 }

--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -58,17 +58,6 @@ define(function(require){
       return returnVal;
     },
 
-    postRender: function() {
-      this.resize();
-    },
-
-    resize: function() {
-      _.defer(_.bind(function() {
-        var windowHeight = $(window).height();
-        this.$el.height(windowHeight - this.$el.offset().top);
-      }, this));
-    },
-
     evaluateChildStatus: function() {
       this.childrenRenderedCount++;
 
@@ -78,7 +67,6 @@ define(function(require){
 
     postRender: function() {
       this.setupScrollListener();
-      this.resize();
     },
 
     addArticleViews: function() {

--- a/frontend/src/modules/editor/global/less/editor.less
+++ b/frontend/src/modules/editor/global/less/editor.less
@@ -2,8 +2,6 @@
 
 .editor-view {
 
-  overflow-y: scroll;
-
   .editor-container {
     position: relative;
     width: 100%;


### PR DESCRIPTION
handle scrollbar and content height in ContentPaneView

To help with collapsible articles in pageEditor, overflow-y is set to scroll to always show the scrollbars.

fixes #1998 