### PR TITLE
Expose CKEditor‘s extraAllowedContent

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -196,7 +196,7 @@ define([
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
         entities: false,
-        extraAllowedContent: Origin.constants.ckExtraAllowedContent,
+        extraAllowedContent: Origin.constants.ckEditorExtraAllowedContent,
         on: {
           change: function() {
             this.trigger('change', this);

--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -196,7 +196,7 @@ define([
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
         entities: false,
-        extraAllowedContent: 'span(*)',
+        extraAllowedContent: Origin.constants.ckEditorAllowedContent || 'span(*)',
         on: {
           change: function() {
             this.trigger('change', this);

--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -196,7 +196,7 @@ define([
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
         entities: false,
-        extraAllowedContent: Origin.constants.ckEditorAllowedContent,
+        extraAllowedContent: Origin.constants.ckExtraAllowedContent,
         on: {
           change: function() {
             this.trigger('change', this);

--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -196,7 +196,7 @@ define([
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
         entities: false,
-        extraAllowedContent: Origin.constants.ckEditorAllowedContent || 'span(*)',
+        extraAllowedContent: Origin.constants.ckEditorAllowedContent,
         on: {
           change: function() {
             this.trigger('change', this);

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,7 +32,7 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useffmpeg',
   'isProduction',
   'maxLoginAttempts',
-  'ckExtraAllowedContent'
+  'ckEditorExtraAllowedContent'
 ];
 
 /**
@@ -77,7 +77,7 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
-    ckExtraAllowedContent: 'span(*)'
+    ckEditorExtraAllowedContent: 'span(*)'
   };
   this.mconf = {};
   return this;

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -31,7 +31,8 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useSmtp',
   'useffmpeg',
   'isProduction',
-  'maxLoginAttempts'
+  'maxLoginAttempts',
+  'ckEditorAllowedContent'
 ];
 
 /**
@@ -75,7 +76,8 @@ function Configuration() {
   // default settings (overriden by the config json)
   this.conf = {
     root: this.serverRoot,
-    maxLoginAttempts: 3
+    maxLoginAttempts: 3,
+    ckEditorAllowedContent: 'span(*)'
   };
   this.mconf = {};
   return this;

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,7 +32,7 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useffmpeg',
   'isProduction',
   'maxLoginAttempts',
-  'ckEditorAllowedContent'
+  'ckExtraAllowedContent'
 ];
 
 /**
@@ -77,7 +77,7 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
-    ckEditorAllowedContent: 'span(*)'
+    ckExtraAllowedContent: 'span(*)'
   };
   this.mconf = {};
   return this;


### PR DESCRIPTION
Use `ckEditorAllowedContent` config option to allow custom ckeditor filtering.
The config option is not set during installation, let me know if you think it makes sense to add it.

Resolves #1619.