### PR TITLE
Added autoresize feature into ACE editor

### DIFF
--- a/frontend/src/modules/scaffold/views/scaffoldCodeEditorView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldCodeEditorView.js
@@ -50,7 +50,7 @@ define(function(require) {
                 session.on('changeAnnotation', _.bind(this.onChangeAnnotation, this));
                 this.editor.setValue(this.value);
                 this.editor.setAutoScrollEditorIntoView(true);
-                this.editor.setOption("minLines", 15);
+                this.editor.setOption("minLines", 14);
                 this.editor.setOption("maxLines", 45);
             }, this));
 

--- a/frontend/src/modules/scaffold/views/scaffoldCodeEditorView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldCodeEditorView.js
@@ -49,6 +49,9 @@ define(function(require) {
                 session.setMode("ace/mode/" + this.mode);
                 session.on('changeAnnotation', _.bind(this.onChangeAnnotation, this));
                 this.editor.setValue(this.value);
+                this.editor.setAutoScrollEditorIntoView(true);
+                this.editor.setOption("minLines", 15);
+                this.editor.setOption("maxLines", 45);
             }, this));
 
             return this;


### PR DESCRIPTION
## Proposed changes

https://github.com/adaptlearning/adapt_authoring/issues/1527

Currently editing CSS/LESS directly in the AT is quite a bad experience as you are limited to a 200px high editor. This change enables the autoresize feature that makes the editor grow as more code it added. https://ace.c9.io/demo/autoresize.html

I set `minLines: 14` as this is the same as 200px. `maxLines: 45` is 700px, this seems to be a reasonable height for someone who wants to make changes here.