### PR TITLE
log DB-connection error

### DIFF
--- a/install.js
+++ b/install.js
@@ -417,6 +417,9 @@ function configureMasterTenant(callback) {
   installHelpers.showSpinner('Starting server');
   // run the app
   app.run({ skipVersionCheck: true });
+  app.on('serverStartError', function(error) {
+    return exit(1, error.message || error);
+  });
   app.on('serverStarted', function() {
     installHelpers.hideSpinner();
     database.checkConnection(function(error) {

--- a/lib/application.js
+++ b/lib/application.js
@@ -375,6 +375,7 @@ Origin.prototype.startServer = function (options) {
     };
     app.createServer(serverOptions, function (error, server) {
       if (error) {
+        app.emit('serverStartError', error);
         logger.log('fatal', 'error creating server', error);
         return process.exit(1);
       }


### PR DESCRIPTION
fixes #880 

Unfortunately we can only use `lib/database` once the app is started (preload the configuration module). Therefore we can't check potential connection issues earlier in the install script.

This PR emit's an error event when the app can't be started. This is mostly related to not being able to connect to the DB. The install script displays this error message to the user. 
This makes the overall installation experience a bit better, as it gives useful information about what caused the error.