### PR TITLE
auto-generate session secret

### DIFF
--- a/install.js
+++ b/install.js
@@ -109,13 +109,6 @@ installHelpers.getLatestFrameworkVersion(function(error, latestFrameworkTag) {
         default: 'data'
       },
       {
-        name: 'sessionSecret',
-        type: 'string',
-        description: 'Session secret (value used when saving session cookie data)',
-        pattern: /^.+$/,
-        default: 'your-session-secret'
-      },
-      {
         name: 'authoringToolRepository',
         type: 'string',
         description: "Git repository URL to be used for the authoring tool source code",
@@ -274,13 +267,12 @@ function generatePromptOverrides() {
     var configData = JSON.parse(JSON.stringify(configJson).replace(/true/g, '"y"').replace(/false/g, '"n"'));
     configData.install = 'y';
   }
-  // NOTE config.json < cmd args
-  const overrides = _.extend({}, configData, optimist.argv);
 
-  if(optimist.argv.autogenerateSessionToken) {
-    overrides.sessionSecret = crypto.randomBytes(64).toString('hex');
-  }
-  return overrides;
+  const isSessionSecretDefined = USE_CONFIG && configData.sessionSecret;
+  const sessionSecret = (isSessionSecretDefined) ? configData.sessionSecret : crypto.randomBytes(64).toString('hex');
+  addConfig({ sessionSecret: sessionSecret });
+  // NOTE config.json < cmd args
+  return _.extend({}, configData, optimist.argv);
 }
 
 function start() {

--- a/install.js
+++ b/install.js
@@ -5,6 +5,7 @@ var fs = require('fs-extra');
 var optimist = require('optimist');
 var path = require('path');
 var prompt = require('prompt');
+var crypto = require('crypto');
 
 var auth = require('./lib/auth');
 var database = require('./lib/database');
@@ -274,7 +275,12 @@ function generatePromptOverrides() {
     configData.install = 'y';
   }
   // NOTE config.json < cmd args
-  return _.extend({}, configData, optimist.argv);
+  const overrides = _.extend({}, configData, optimist.argv);
+
+  if(optimist.argv.autogenerateSessionToken) {
+    overrides.sessionSecret = crypto.randomBytes(64).toString('hex');
+  }
+  return overrides;
 }
 
 function start() {

--- a/install.js
+++ b/install.js
@@ -268,8 +268,7 @@ function generatePromptOverrides() {
     configData.install = 'y';
   }
 
-  const isSessionSecretDefined = USE_CONFIG && configData.sessionSecret;
-  const sessionSecret = (isSessionSecretDefined) ? configData.sessionSecret : crypto.randomBytes(64).toString('hex');
+  const sessionSecret = USE_CONFIG && configData.sessionSecret || crypto.randomBytes(64).toString('hex');
   addConfig({ sessionSecret: sessionSecret });
   // NOTE config.json < cmd args
   return _.extend({}, configData, optimist.argv);


### PR DESCRIPTION
Session-secret is autogenereated by default. If a session-secret is defined in config.json, this is used.
Also removes the prompt to enter the session-secret.

fixes #2007 
