### PR TITLE
Pin mongoose to v5.1.* to stop deprication warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "migrate-mongoose": "^3.2.2",
     "mime": "^2.3.1",
     "moment": "^2.22.1",
-    "mongoose": "^5.1.1",
+    "mongoose": "~5.1.1",
     "morgan": "^1.9.0",
     "multer": "^1.3.0",
     "needle": "^2.2.1",


### PR DESCRIPTION
See issues #2028 and #2053 . [This post](https://stackoverflow.com/questions/50448272/avoid-current-url-string-parser-is-deprecated-warning-by-setting-usenewurlpars#) gives a good explanation.

I think pinning mongoose is a safer option than implementing the changes to mongoose connection options unless we need any fixes in mongoose v5.2.* or support for mongoDB v4.0. 

We should specify which mongoDB versions we support in the docs as the mongoose driver we have specified only supports MongoDB >=3.*. See [version compatibility](https://mongoosejs.com/docs/compatibility.html).