### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/dml/mongoose/index.js
+++ b/lib/dml/mongoose/index.js
@@ -10,6 +10,7 @@ var Database = require('../../database').Database,
     _ = require('underscore');
 
 mongoose.Promise = global.Promise;
+mongoose.set('useCreateIndex', true);
 
 // private functions
 function transformArrayAttributes (schema) {
@@ -67,6 +68,7 @@ MongooseDB.prototype.connect = function(db) {
   dbReplicaset = configuration.getConfig('dbReplicaset');
   options = configuration.getConfig('dbOptions') || {};
   options.domainsEnabled = true;
+  options.useNewUrlParser = true;
 
   // Construct the authentication part of the connection string.
   authenticationString = dbUser && dbPass ? dbUser + ':' + dbPass + '@' : '';
@@ -435,7 +437,7 @@ MongooseDB.prototype.update = function(objectType, conditions, updateData, callb
 MongooseDB.prototype.destroy = function(objectType, conditions, callback) {
   var Model = false;
   if (Model = this.getModel(objectType)) {
-    Model.remove(conditions, callback);
+    Model.deleteMany(conditions, callback);
   } else {
     callback(new Error('MongooseDB#destroy: Failed to retrieve model with name ' + objectType));
   }

--- a/test/entry.js
+++ b/test/entry.js
@@ -107,7 +107,10 @@ function removeTestData(done) {
     function dumpOldDb(cb) {
       var MongoClient = mongodb.MongoClient;
       var connStr = 'mongodb://' + testConfig.dbHost + ':' + testConfig.dbPort + '/' + testConfig.dbName;
-      MongoClient.connect(connStr, { domainsEnabled: true }, function(error, client) {
+      MongoClient.connect(connStr, {
+        domainsEnabled: true,
+        useNewUrlParser: true
+      }, function(error, client) {
         if(error) return cb(error);
 
         var db = client.db(testConfig.dbName);


### PR DESCRIPTION
Future-proofs and goes a fair way in resolving #2028 & #2053.

The outstanding warning stems from the third-party [connect-mongo](https://github.com/jdesboeufs/connect-mongo/issues/297) module:
```shellsession
DeprecationWarning: collection.update is deprecated. Use updateOne, updateMany, or bulkWrite instead.
```