### PR TITLE
Expose CKEditor's enterMode

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -70,6 +70,7 @@ define([
       this.editor = CKEDITOR.replace(this.$el[0], {
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
+        enterMode: CKEDITOR[Origin.constants.ckEditorEnterMode],
         entities: false,
         extraAllowedContent: Origin.constants.ckEditorExtraAllowedContent,
         on: {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,6 +32,7 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useffmpeg',
   'isProduction',
   'maxLoginAttempts',
+  'ckEditorEnterMode',
   'ckEditorExtraAllowedContent'
 ];
 
@@ -77,6 +78,7 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
+    ckEditorEnterMode: 'ENTER_P',
     ckEditorExtraAllowedContent: 'span(*)'
   };
   this.mconf = {};


### PR DESCRIPTION
Adds a configuration option to resolve #1898.

Have left the default as wrapping in `<p>` tags for legacy purposes and the fact it's not [universally recommended](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_enterkey.html).