### PR TITLE
Stop export excluding course.model.schema

### DIFF
--- a/plugins/output/adapt/index.js
+++ b/plugins/output/adapt/index.js
@@ -313,7 +313,7 @@ function copyFrameworkFiles(results, filesCopied) {
       includes[i] = '\/' + includes[i] + '(\/|$)';
 
     var includesRE = new RegExp(includes.join('|'));
-    var excludesRE = new RegExp(/\.git\b|\.DS_Store|\/node_modules|\/courses\b|\/course\b|\/exports\b/);
+    var excludesRE = new RegExp(/\.git\b|\.DS_Store|\/node_modules|\/courses\b|\/course\b(?!\.)|\/exports\b/);
     var pluginsRE = new RegExp('\/components\/|\/extensions\/|\/menu\/|\/theme\/');
 
     fs.copy(FRAMEWORK_ROOT_DIR, EXPORT_DIR, {


### PR DESCRIPTION
Fixes #1512. Currently one of the core framework schemas is excluded from export source due to [this](https://github.com/adaptlearning/adapt_authoring/blob/master/plugins/output/adapt/index.js#L316) line.  This prevents the grunt translation task on the exported framework.

## Proposed changes
Re-add the negative look ahead that [previously](https://github.com/adaptlearning/adapt_authoring/pull/1601/files#diff-df68ee67d4821734092e7178fd97957aR309) fixed this. 

Do we need to add this for node_module and courses as well? 
