### PR TITLE
maxFileUploadSize config option

### DIFF
--- a/frontend/src/modules/assetManagement/views/assetManagementNewAssetView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementNewAssetView.js
@@ -54,13 +54,24 @@ define(function(require){
         }
       });
 
+      var fileInput = this.$('.asset-file')[0];
+      var isFileTooBig = fileInput.files[0] && fileInput.files[0].size > Origin.constants.maxFileUploadSize;
+      if (isFileTooBig) {
+        $(uploadFileErrormsg).text(Origin.l10n.t('app.assetfilesizeexceeded', {
+          uploadLimit: Origin.constants.humanMaxFileUploadSize
+        }));
+        validated = false;
+      }
+
       if (this.model.isNew() && !uploadFile.val()) {
         validated = false;
         $(uploadFile).addClass('input-error');
         $(uploadFileErrormsg).text(Origin.l10n.t('app.pleaseaddfile'));
       } else {
         $(uploadFile).removeClass('input-error');
-        $(uploadFileErrormsg).text('');
+        if (!isFileTooBig) {
+          $(uploadFileErrormsg).text('');
+        }
       }
       return validated;
     },

--- a/frontend/src/modules/frameworkImport/views/frameworkImportView.js
+++ b/frontend/src/modules/frameworkImport/views/frameworkImportView.js
@@ -29,18 +29,25 @@ define(function(require){
 
     isValid: function() {
       var uploadFile = this.$('.asset-file');
-      var validated = true;
       var uploadFileErrormsg = $('.field-file').find('span.error');
+      var isFileTooBig = uploadFile[0].files[0] && uploadFile[0].files[0].size > Origin.constants.maxFileUploadSize;
 
       if (this.model.isNew() && !uploadFile.val()) {
         validated = false;
         $(uploadFile).addClass('input-error');
         $(uploadFileErrormsg).text(Origin.l10n.t('app.pleaseaddfile'));
+        return false;
+      } else if(isFileTooBig) {
+        $(uploadFile).addClass('input-error');
+        $(uploadFileErrormsg).text(Origin.l10n.t('app.assetfilesizeexceeded', {
+          uploadLimit: Origin.constants.humanMaxFileUploadSize
+        }));
+        return false;
       } else {
         $(uploadFile).removeClass('input-error');
         $(uploadFileErrormsg).text('');
       }
-      return validated;
+      return true;
     },
 
     uploadCourse: function(sidebarView) {

--- a/frontend/src/modules/pluginManagement/views/pluginManagementUploadView.js
+++ b/frontend/src/modules/pluginManagement/views/pluginManagementUploadView.js
@@ -30,13 +30,30 @@ define(function(require){
     },
 
     validate: function() {
-      if(_.isEmpty(this.$('form input').val())) {
-        this.$('.field-error').removeClass('display-none');
+      var inputField = this.$('form input');
+      var isValid = true;
+      var message = '';
+
+      if (_.isEmpty(inputField.val())) {
+        isValid = false;
+        message = Origin.l10n.t('app.required');
+      }
+
+      if (inputField[0].files[0] && inputField[0].files[0].size > Origin.constants.maxFileUploadSize) {
+        isValid = false;
+        message = Origin.l10n.t('app.assetfilesizeexceeded', {
+          uploadLimit: Origin.constants.humanMaxFileUploadSize
+        });
+      }
+
+      if (isValid) {
+        this.$('.field-error').addClass('display-none');
+        return true;
+      } else {
+        this.$('.field-error').text(message).removeClass('display-none');
         Origin.trigger('sidebar:resetButtons');
         return false;
       }
-      this.$('.field-error').addClass('display-none');
-      return true;
     },
 
     onUploadSuccess: function(data) {

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -384,8 +384,16 @@ exports = module.exports = {
 
   postAsset: function (req, res, next) {
     var form = new IncomingForm();
+    form.maxFileSize = configuration.getConfig('maxFileUploadSize');
+
     var self = this;
+
     form.parse(req, function (error, fields, files) {
+      if (form.bytesExpected > form.maxFileSize) {
+        logger.log('error', `File size limit exceeded: ${form.bytesExpected} of ${form.maxFileSize}.`)
+        return next();
+      }
+
       if (error) {
         return next(error);
       }

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -79,7 +79,8 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
-    ckEditorExtraAllowedContent: 'span(*)'
+    ckEditorExtraAllowedContent: 'span(*)',
+    maxFileUploadSize: '200mb'
   };
   this.mconf = {};
   return this;
@@ -150,7 +151,7 @@ Configuration.prototype.setConfig = function (name, value) {
  */
 Configuration.prototype.getConfig = function (name) {
   if (name === 'maxFileUploadSize') {
-    return bytes.parse(this.conf.maxFileUploadSize) || (200 * 1024 * 1024);
+    return bytes.parse(this.conf.maxFileUploadSize);
   }
 
   if (name && typeof name === 'string') {
@@ -179,7 +180,9 @@ Configuration.prototype.getAllClientSideConfigs = function() {
     if (!configs.hasOwnProperty(key)) return result;
     result[key] = this.getConfig(key);
     return result;
-  }, {});
+  }, {
+    humanMaxFileUploadSize: configs['maxFileUploadSize']
+  });
 };
 
 /**

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -12,12 +12,13 @@
  * Module depencies
  */
 
-var fs = require('fs'),
-    path = require('path'),
-    _ = require('underscore'),
-    EventEmitter = require('events').EventEmitter,
-    util = require('util'),
-    logger = require('./logger');
+const fs = require('fs');
+const path = require('path');
+const _ = require('underscore');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const logger = require('./logger');
+const bytes = require('bytes');
 
 /*
  * CONSTANTS
@@ -32,7 +33,8 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useffmpeg',
   'isProduction',
   'maxLoginAttempts',
-  'ckEditorExtraAllowedContent'
+  'ckEditorExtraAllowedContent',
+  'maxFileUploadSize'
 ];
 
 /**
@@ -147,6 +149,10 @@ Configuration.prototype.setConfig = function (name, value) {
  * @api public
  */
 Configuration.prototype.getConfig = function (name) {
+  if (name === 'maxFileUploadSize') {
+    return bytes.parse(this.conf.maxFileUploadSize) || (200 * 1024 * 1024);
+  }
+
   if (name && typeof name === 'string') {
     return (this.conf[name] || '');
   }
@@ -166,13 +172,14 @@ Configuration.prototype.getConfig = function (name) {
  */
 Configuration.prototype.getAllClientSideConfigs = function() {
   var configs = this.getConfig();
+  if (!configs) return null;
 
-  if (configs) {
-    // Only return allowed values
-    return _.pick(configs, ALLOWED_CLIENT_SIDE_KEYS);
-  }
-
-  return null;
+  // Only return allowed values
+  return ALLOWED_CLIENT_SIDE_KEYS.reduce((result, key) => {
+    if (!configs.hasOwnProperty(key)) return result;
+    result[key] = this.getConfig(key);
+    return result;
+  }, {});
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.18.3",
     "bower": "^1.8.4",
+    "bytes": "^3.0.0",
     "chalk": "^2.4.1",
     "compression": "^1.7.2",
     "connect-mongo": "^2.0.1",

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -885,7 +885,12 @@ function checkIfHigherVersionExists (package, options, cb) {
 
 function handleUploadedPlugin (req, res, next) {
   var form = new IncomingForm();
+  form.maxFileSize = configuration.getConfig('maxFileUploadSize');
   form.parse(req, function (error, fields, files) {
+    if (form.bytesExpected > form.maxFileSize) {
+      return next(new PluginPackageError(`File size limit exceeded: ${form.bytesExpected} of ${form.maxFileSize}.`));
+    }
+
     if (error) {
       return next(error);
     }

--- a/plugins/output/adapt/importsource.js
+++ b/plugins/output/adapt/importsource.js
@@ -52,6 +52,7 @@ function ImportSource(req, done) {
   var courseRoot = path.join(COURSE_ROOT_FOLDER, Constants.Folders.Source, Constants.Folders.Course);
 
   var form = new IncomingForm();
+  form.maxFileSize = configuration.getConfig('maxFileUploadSize');
   var origCourseId;
   var courseId;
   var configId;

--- a/routes/lang/en-application.json
+++ b/routes/lang/en-application.json
@@ -73,6 +73,7 @@
   "app.noprojectstodisplay": "No courses to display",
   "app.pleaseentervalue": "Please enter a value here",
   "app.pleaseaddfile": "Please choose a file to upload",
+  "app.assetfilesizeexceeded": "File is too large, maximum file size is %{uploadLimit}",
   "app.addarticle": "Add article",
   "app.addblock": "Add block",
   "app.addcomponent": "Add component",


### PR DESCRIPTION
fixes #2095 

Exposes `maxFileUploadSize` to config.json. Defaults to 200mb. Uses [bytes](https://github.com/visionmedia/bytes.js#bytesparsestringnumber-value-numbernull) to parses a human redable string e.g. `200kb|50mb|1gb`.
