### PR TITLE
Remove instruction from component schema

### DIFF
--- a/plugins/content/component/model.schema
+++ b/plugins/content/component/model.schema
@@ -99,12 +99,6 @@
       "validators": [],
       "translatable": true
     },
-    "instruction": {
-      "type": "string",
-      "default" : "",
-      "inputType": "Text",
-      "translatable": true
-    },
     "_onScreen": {
       "type": "object",
       "title": "On-screen classes",


### PR DESCRIPTION
Reverts the duplication of instruction text in the core schema for now.

The move from plugins to core isn't going to land until at least framework v5 and there'll no doubt be wholescale changes to the schema when support is added for multiple framework versions.

Resolves #2061.