### PR TITLE
Sort plugins alphabetically on pluginManagement pages

### DIFF
--- a/frontend/src/modules/editor/global/collections/editorCollection.js
+++ b/frontend/src/modules/editor/global/collections/editorCollection.js
@@ -4,6 +4,8 @@ define(function(require) {
   var Origin = require('core/origin');
 
   var EditorCollection = Backbone.Collection.extend({
+    comparator: 'displayName',
+
     initialize : function(models, options){
       this.url = options.url;
       this._type = options._type;
@@ -15,15 +17,6 @@ define(function(require) {
 
     loadedData: function() {
       Origin.trigger('editorCollection:dataLoaded', this._type);
-    },
-
-    comparator: function(item) {
-      return item.get(this.sort_key);
-    },
-
-    sortByField: function(fieldName) {
-      this.sort_key = fieldName;
-      return this.sort();
     }
   });
 

--- a/frontend/src/modules/editor/global/editorDataLoader.js
+++ b/frontend/src/modules/editor/global/editorDataLoader.js
@@ -204,7 +204,7 @@ define(function(require) {
       model: Model,
       url: url,
       _type: siblingTypes || inferredType
-    }).sortByField('displayName');
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes #2145 

To test go to the plugin management area and view the pages, all components/extensions/themes/menus are now sorted alphabetically.