### PR TITLE
Scaffold fallback editors

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -33,6 +33,25 @@ define([
     });
   };
 
+  Backbone.Form.Field.prototype.createEditor = function() {
+    var options = _.extend(_.pick(this, 'schema', 'form', 'key', 'model', 'value'), { id: this.createEditorId() });
+
+    if (this.schema.type) {
+      return new this.schema.type(options);
+    }
+
+    var fallbackType = this.schema.inputType.fallbackType;
+    if (fallbackType && Backbone.Form.editors[fallbackType]) {
+      this.schema.type = Backbone.Form.editors[fallbackType];
+      this.schema.inputType = fallbackType;
+      return new this.schema.type(options);
+    }
+
+    this.schema.inputType = "Text";
+    this.schema.type = Backbone.Form.editors.Text;
+    return new this.schema.type(options);
+  };
+
   // use default from schema and set up isDefaultValue toggler
   Backbone.Form.editors.Base.prototype.initialize = function(options) {
     var schemaDefault = options.schema.default;


### PR DESCRIPTION
This PR is not meant to be merged ... 

We can't really do anything to prevent old / existing AT users from installing plugins that introduce new scaffold editors.

To make things more robust, we could patch Backbone Forms to support editor fallbacks.
Plugins could specify a fallback editor:
```
"src": {
          "type": "string",
          "required": false,
          "default": "",
          "inputType": {
                "type": "AssetItem",  // <-- drag-and-drop UI
                "fallbackType": "Asset:image", // <-- old UI
          	"items": "_items",
          	"topAttribute": "_top",
          	"leftAttribute": "_left",
          	"precision": 2
          },
          "validators": [],
          "help": "This is the image that appears behind the pins"
}
```
If the fallback editor is also not available, we could simply use the TextEditor. This will make sure that the CourseEditor still works.

Ideally this is combined with a UI to change Plugin Versions to roll back to a previous version.