### PR TITLE
Use masterTenantDisplayName for displayName on install instead of masterTenantName

### DIFF
--- a/install.js
+++ b/install.js
@@ -417,7 +417,7 @@ function configureMasterTenant(callback) {
       addConfig({
         masterTenant: {
           name: result.masterTenantName,
-          displayName: result.masterTenantName
+          displayName: result.masterTenantDisplayName
         }
       });
       // check if the tenant name already exists


### PR DESCRIPTION
This one has been bugging me for a while. 

Can update target branch to 0.7.1 once we have the release branch, or add to 0.7.0 milestone.
