### PR TITLE
Revert sidebar filters to be off by default

### DIFF
--- a/frontend/src/modules/sidebar/templates/sidebarFieldsetFilter.hbs
+++ b/frontend/src/modules/sidebar/templates/sidebarFieldsetFilter.hbs
@@ -1,6 +1,6 @@
 <button class="sidebar-fieldset-filter sidebar-fieldset-filter-{{stringToClassName legend}}">
 	<span class="sidebar-fieldset-filter-inner">
-		<i class="fa fa-toggle-off fa-toggle-on"></i>
+		<i class="fa fa-toggle-off"></i>
 		{{legend}}
 	</span>
 </button>

--- a/frontend/src/modules/sidebar/views/sidebarFieldsetFilterView.js
+++ b/frontend/src/modules/sidebar/views/sidebarFieldsetFilterView.js
@@ -10,7 +10,6 @@ define(function(require) {
 		},
 
 		initialize: function() {
-			this.onFilterClicked(this); // Hack used for #1184. Sure there must be a better way to turn on.
 			this.listenTo(Origin, 'remove:views', this.remove);
 			this.render();
 		},


### PR DESCRIPTION
Resolves #1327.

This one has caused head scratching for a while now. In the absence of an imminent UI rewrite and @taylortom's nice tabs suggestion, I'd like to make a push for this reversion to make the toggles less useless in the meantime and also to align with the asset manager for consistency.
