### PR TITLE
Pass through editorAttrs correctly

### DIFF
--- a/frontend/src/modules/scaffold/templates/field.hbs
+++ b/frontend/src/modules/scaffold/templates/field.hbs
@@ -1,4 +1,4 @@
-{{#unless editorAttrs.isHidden}}<div class="field{{#if title}} field-{{stringToClassName title}}{{else}}{{#if legend}} field-object field-object-{{stringToClassName legend}}{{/if}}{{/if}}{{#if isDefaultValue}} is-default-value{{/if}}" data-editor-id="{{editorId}}" data-type="{{#if inputType.type}}{{inputType.type}}{{else}}{{inputType}}{{/if}}">
+<div {{#each editorAttrs}}{{@key}}="{{this}}" {{/each}}class="field{{#if title}} field-{{stringToClassName title}}{{else}}{{#if legend}} field-object field-object-{{stringToClassName legend}}{{/if}}{{/if}}{{#if isDefaultValue}} is-default-value{{/if}}" data-editor-id="{{editorId}}" data-type="{{#if inputType.type}}{{inputType.type}}{{else}}{{inputType}}{{/if}}">
   {{#if title}}
   <label for="{{editorId}}">{{title}}</label>
   <div class="field-help">
@@ -24,4 +24,4 @@
     <div class="field-error" data-error></div>
     <span data-editor></span>
   </div>
-</div>{{/unless}}
+</div>

--- a/frontend/src/modules/scaffold/templates/field.hbs
+++ b/frontend/src/modules/scaffold/templates/field.hbs
@@ -1,4 +1,4 @@
-<div class="field{{#if title}} field-{{stringToClassName title}}{{else}}{{#if legend}} field-object field-object-{{stringToClassName legend}}{{/if}}{{/if}}{{#if isDefaultValue}} is-default-value{{/if}}" data-editor-id="{{editorId}}" data-type="{{#if inputType.type}}{{inputType.type}}{{else}}{{inputType}}{{/if}}">
+{{#unless editorAttrs.isHidden}}<div class="field{{#if title}} field-{{stringToClassName title}}{{else}}{{#if legend}} field-object field-object-{{stringToClassName legend}}{{/if}}{{/if}}{{#if isDefaultValue}} is-default-value{{/if}}" data-editor-id="{{editorId}}" data-type="{{#if inputType.type}}{{inputType.type}}{{else}}{{inputType}}{{/if}}">
   {{#if title}}
   <label for="{{editorId}}">{{title}}</label>
   <div class="field-help">
@@ -24,4 +24,4 @@
     <div class="field-error" data-error></div>
     <span data-editor></span>
   </div>
-</div>
+</div>{{/unless}}


### PR DESCRIPTION
Passing through editorAttrs correctly allows you to use `editorAttrs` to add attributes to fields such as allowing them to be hidden with this syntax

```json
"editorAttrs": {
  "hidden": ""
},
```
This is useful for passing initial states, extra data or perhaps just properties that should only be changed in the framework.

For documentation changes, I didn't know which files to update, I presume it would actually be a wiki change? 

Very **loosely** connected to #2342

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adaptlearning/adapt_authoring/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have checked that the code compiles correctly
- [x] I have checked that unit test suite passes locally with my changes
- [x] I have added new tests that cover my changes (where appropriate)
- [ ] I have added documentation (where appropriate)
- [x] Any dependent changes have already been merged