### PR TITLE
Performance improvements

### DIFF
--- a/frontend/src/modules/scaffold/schemas.js
+++ b/frontend/src/modules/scaffold/schemas.js
@@ -38,7 +38,6 @@ define([ 'core/origin', './models/schemasModel' ], function(Origin, SchemasModel
   function trimGlobals(schema) {
     var globals = schema._globals.properties;
     trimDisabledPlugins(globals._extensions, _.values(configModel.get('_enabledExtensions')));
-    trimDisabledPlugins(globals._components, configModel.get('_enabledComponents'), '_component');
     trimDisabledPlugins(globals._menu, editorData.menutypes.where({ name: configModel.get('_menu') }));
     trimDisabledPlugins(globals._theme, editorData.themetypes.where({ name: configModel.get('_theme') }));
     // trim off the empty globals objects

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -144,7 +144,45 @@ function getConfigJson(courseId, callback) {
       if (config.length !== 1) {
         return callback(new Error('Preview/Publish: Unable to retrieve config.json'));
       }
-      callback(null, { config: [flattenNestedObjects(config[0])] });
+
+      origin().contentmanager.getContentPlugin('component', function (err, componentPlugin) {
+        componentPlugin.retrieve({_courseId: courseId}, function(err, components) {
+          // Retrieve the component types.
+          database.getDatabase(function(err, db) {
+            if (err) {
+              logger.log('error', err);
+              return next(err);
+            }
+
+            db.retrieve('componenttype', {}, function(err, componentTypes) {
+              if (err) {
+                return next(err);
+              }
+
+              var uniqueComponents = _.uniq(components, false, function(component) {
+                return component._component;
+              });
+
+              async.map(uniqueComponents, function(component, callback) {
+                var componentType = _.findWhere(componentTypes, {component: component._component});
+                // Adding an _ here is necessary because of the way the attributes are set
+                // onto the _globals object on the schemas
+                var definition = {
+                  name: componentType.name,
+                  _componentType: component._componentType,
+                  _component: "_" + component._component
+                };
+                return callback(null, definition);
+              }, function(err, uniqueComponentList) {
+                var configModel = config[0].toObject();
+                configModel._enabledComponents = uniqueComponentList;
+
+                callback(null, { config: [flattenNestedObjects(configModel)] });
+              });
+            });
+          }, configuration.getConfig('dbName'));
+        })
+      });
     });
   });
 }
@@ -276,13 +314,10 @@ OutputPlugin.prototype.sanitizeCourseJSON = function(mode, json, next) {
 OutputPlugin.prototype.generateIncludesForCourse = function(courseId, next) {
   async.waterfall([
     (callback) => {
-      origin().contentmanager.getContentPlugin('config', callback);
+      getConfigJson(courseId, callback);
     },
-    (contentPlugin, callback) => {
-      contentPlugin.retrieve({ _courseId: courseId }, {}, callback);
-    },
-    (config, callback) => {
-      this.generateIncludesForConfig(config[0], (error, includes) => {
+    (json, callback) => {
+      this.generateIncludesForConfig(json.config[0], (error, includes) => {
         if(error) {
           return callback(error);
         }
@@ -338,7 +373,9 @@ function generateIncludedPlugins(config) {
     // string, store and return
     if(typeof val === 'string') return includedPlugins.push([ pluginTypeInfo.folder, val ]);
     // either object or array, store each 'name' value
-    for(var i in val) includedPlugins.push([ pluginTypeInfo.folder, val[i].name ]);
+    for(var i in val) {
+      if (typeof val[i].name !== 'undefined') includedPlugins.push([ pluginTypeInfo.folder, val[i].name ]);
+    }
   });
   return includedPlugins;
 }

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -145,44 +145,31 @@ function getConfigJson(courseId, callback) {
         return callback(new Error('Preview/Publish: Unable to retrieve config.json'));
       }
 
-      origin().contentmanager.getContentPlugin('component', function (err, componentPlugin) {
-        componentPlugin.retrieve({_courseId: courseId}, function(err, components) {
-          // Retrieve the component types.
-          database.getDatabase(function(err, db) {
+      // Retrieve the component types.
+      database.getDatabase(function(err, db) {
+        if (err) {
+          logger.log('error', err);
+          return next(err);
+        }
+
+        db.retrieve('component', {_courseId: courseId}, {operators: {distinct: '_component'}}, function (err, components) {
+          db.retrieve('componenttype', {}, function(err, componentTypes) {
             if (err) {
-              logger.log('error', err);
               return next(err);
             }
 
-            db.retrieve('componenttype', {}, function(err, componentTypes) {
-              if (err) {
-                return next(err);
-              }
+            async.map(components, function(component, callback) {
+              var componentType = _.findWhere(componentTypes, {component: component});
+              return callback(null, { name: componentType.name });
+            }, function(err, uniqueComponentList) {
+              var configModel = config[0].toObject();
+              configModel._enabledComponents = uniqueComponentList;
 
-              var uniqueComponents = _.uniq(components, false, function(component) {
-                return component._component;
-              });
-
-              async.map(uniqueComponents, function(component, callback) {
-                var componentType = _.findWhere(componentTypes, {component: component._component});
-                // Adding an _ here is necessary because of the way the attributes are set
-                // onto the _globals object on the schemas
-                var definition = {
-                  name: componentType.name,
-                  _componentType: component._componentType,
-                  _component: "_" + component._component
-                };
-                return callback(null, definition);
-              }, function(err, uniqueComponentList) {
-                var configModel = config[0].toObject();
-                configModel._enabledComponents = uniqueComponentList;
-
-                callback(null, { config: [flattenNestedObjects(configModel)] });
-              });
+              callback(null, { config: [flattenNestedObjects(configModel)] });
             });
-          }, configuration.getConfig('dbName'));
-        })
-      });
+          });
+        });
+      }, configuration.getConfig('dbName'));
     });
   });
 }

--- a/plugins/content/config/index.js
+++ b/plugins/content/config/index.js
@@ -148,55 +148,8 @@ ConfigContent.prototype.retrieve = function (search, options, next) {
     if (!records || records.length == 0) {
       return next(new Error(`Unable to retrieve ${modelName} for ${JSON.stringify(search)}`));
     }
-    
-    // When passing down the config model we should 
-    // find out how many and what components are being used
-    // Why you might ask - to sort out _globals and when compiling
-    // this should act as a filter
-    app.contentmanager.getContentPlugin('component', function (err, componentPlugin) {
-      var courseId = records[0]._courseId;
-      componentPlugin.retrieve({_courseId: courseId}, function(err, components) {
 
-        // Retrieve the component types.
-        database.getDatabase(function(err, db) {
-          if (err) {
-            logger.log('error', err);
-            return next(err);
-          }
-          
-          db.retrieve('componenttype', {}, function(err, componentTypes) {
-            if (err) {
-              return next(err);
-            }
-            
-            var uniqueComponents = _.uniq(components, false, function(component) {
-              return component._component;
-            });
-    
-            async.map(uniqueComponents, function(component, callback) {
-              var componentType = _.findWhere(componentTypes, {component: component._component});
-              
-              // Adding an _ here is necessary because of the way the attributes are set
-              // onto the _globals object on the schemas
-              var definition = {
-                name: componentType.name, 
-                _componentType: component._componentType, 
-                _component: "_" + component._component
-              };
-              
-              return callback(null, definition);
-    
-            }, function(err, uniqueComponentList) {
-    
-              var configModel = records[0].toObject();
-              configModel._enabledComponents = uniqueComponentList;
-    
-              return next(null, [configModel]);
-            });    
-          });
-        }, configuration.getConfig('dbName'));
-      })
-    });
+    return next(null, [records[0]]);
   });
 };
 

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -46,7 +46,7 @@ function publishCourse(courseId, mode, request, response, next) {
     return stdout.substring(indexStart, indexEnd !== -1 ? indexEnd : stdout.length);
   }
 
-  async.series([
+  async.waterfall([
     // get an object with all the course data
     function(callback) {
       self.getCourseJSON(tenantId, courseId, function(err, data) {
@@ -200,7 +200,7 @@ function publishCourse(courseId, mode, request, response, next) {
           });
       });
     },
-    function(callback) {
+    function(err, callback) {
       self.clearBuildFlag(path.join(BUILD_FOLDER, Constants.Filenames.Rebuild), function(err) {
         callback(null);
       });


### PR DESCRIPTION
Fixes #2370 

- On every AT editor page load the config is retrieved
- In plugins/content/config/index.js there was some code which did the following on every config load:
    - Get every component in the course
    - Iterate through every component and check if the user has permission
    - Strip down the list of components to a unique list (ie one of each type)
    - Use this list to make the "_enabledComponents" list

- The enabledComponents list is not required when navigating around the editor, so this code has been moved into a place in the outputmanger where it is used by preview/export/publish only
- Changes have been made to the moved code to make it more efficient, instead of retrieving every component in the course it just retrieves a list of types (eg. text, mcq)

QA have tested this internally