### PR TITLE
Fix preset always defaulting to 'none'

### DIFF
--- a/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
+++ b/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
@@ -108,6 +108,7 @@ define(function(require) {
 
     postRender: function() {
       this.updateSelects();
+      this.setPresetSelection(Origin.editor.data.course.get('lastSelectedThemePresetId'));
       this.setViewToReady();
 
       this.$el.show();
@@ -297,9 +298,9 @@ define(function(require) {
         return Origin.trigger('sidebar:resetButtons');
       }
 
-      this.postThemeData(function(){
-        this.postPresetData(function() {
-          this.postSettingsData(this.onSaveSuccess);
+      this.postSettingsData(function(){
+        this.postThemeData(function() {
+          this.postPresetData(this.onSaveSuccess);
         });
       });
     },
@@ -502,7 +503,7 @@ define(function(require) {
     },
 
     onThemeChanged: function() {
-      this.setPresetSelection(null);
+      this.setPresetSelection(Origin.editor.data.course.get('lastSelectedThemePresetId'));
       this.updatePresetSelect();
       this.renderForm();
       this.updateRestorePresetButton(false);

--- a/frontend/src/modules/scaffold/schemas.js
+++ b/frontend/src/modules/scaffold/schemas.js
@@ -16,6 +16,7 @@ define([ 'core/origin', './models/schemasModel' ], function(Origin, SchemasModel
       delete schema.menuSettings;
       delete schema.themeSettings;
       delete schema.themeVariables;
+      delete schema.lastSelectedThemePresetId;
       return schema;
     }
     trimPlugins(schema);

--- a/plugins/content/themepreset/index.js
+++ b/plugins/content/themepreset/index.js
@@ -34,7 +34,7 @@ ThemePresetContent.prototype.updatePreset = function(presetId, courseId, res, ne
     app.contentmanager.update('config', { _courseId: courseId }, JSON.stringify(delta), function(err) {
       if (err) return next(err);
       // lose any previously set theme settings, preset overrides
-      app.contentmanager.update('course', { _id: courseId }, { _courseId: courseId, themeSettings: null }, function(err) {
+      app.contentmanager.update('course', { _id: courseId }, { _courseId: courseId, themeSettings: null, lastSelectedThemePresetId: presetId }, function(err) {
         if (err) return next(err);
         // force a rebuild of the course
         var tenantId = Usermanager.getCurrentUser().tenant._id;

--- a/plugins/content/themepreset/index.js
+++ b/plugins/content/themepreset/index.js
@@ -33,7 +33,7 @@ ThemePresetContent.prototype.updatePreset = function(presetId, courseId, res, ne
 
     app.contentmanager.update('config', { _courseId: courseId }, JSON.stringify(delta), function(err) {
       if (err) return next(err);
-      // lose any previously set theme settings, preset overrides
+      // lose any previously set theme settings, preset overrides, store new preset id
       app.contentmanager.update('course', { _id: courseId }, { _courseId: courseId, themeSettings: null, lastSelectedThemePresetId: presetId }, function(err) {
         if (err) return next(err);
         // force a rebuild of the course


### PR DESCRIPTION
Fixes #2379 

There will be a corresponding framework PR - I will link it below when this is made.

- When a preset has been selected, re-select it when returning to the page
- If the user switches theme and switches back, maintain their saved settings for original theme