### PR TITLE
Fix preset dropdown always defaulting to 'no preset'

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -162,7 +162,7 @@ function getConfigJson(courseId, callback) {
               var componentType = _.findWhere(componentTypes, {component: component});
               return callback(null, { name: componentType.name });
             }, function(err, uniqueComponentList) {
-              var configModel = config[0].toObject();
+              var configModel = config[0];
               configModel._enabledComponents = uniqueComponentList;
 
               callback(null, { config: [flattenNestedObjects(configModel)] });

--- a/plugins/content/config/index.js
+++ b/plugins/content/config/index.js
@@ -150,7 +150,7 @@ ConfigContent.prototype.retrieve = function (search, options, next) {
       return next(new Error(`Unable to retrieve ${modelName} for ${JSON.stringify(search)}`));
     }
 
-    return next(null, [records[0]]);
+    return next(null, [records[0].toObject()]);
   });
 };
 

--- a/plugins/content/themepreset/index.js
+++ b/plugins/content/themepreset/index.js
@@ -31,7 +31,7 @@ ThemePresetContent.prototype.updatePreset = function(presetId, courseId, res, ne
     }
     delta._courseId = courseId;
 
-    app.contentmanager.update('config', { _courseId: courseId }, JSON.stringify(delta), function(err) {
+    app.contentmanager.update('config', { _courseId: courseId }, delta, function(err) {
       if (err) return next(err);
       // lose any previously set theme settings, preset overrides
       app.contentmanager.update('course', { _id: courseId }, { _courseId: courseId, themeSettings: null }, function(err) {


### PR DESCRIPTION
Fixes #2379 

In https://github.com/adaptlearning/adapt_authoring/pull/2371/files in plugins/content/config/index.js the following was removed

```
var configModel = records[0].toObject();
configModel._enabledComponents = uniqueComponentList;
return next(null, [configModel]);
```
and replaced with 

`return next(null, [records[0]]);`

This missing .toObject led to the following change https://github.com/adaptlearning/adapt_authoring/commit/33600c3cc30c42ff6709996b0ddbfe997b14929e#diff-6cb64d73a547a24bfc001f80bb7192dc

These two things meant that the _themePreset value was no longer being saved. Fixing these things allows the last selected preset to be saved successfully which fixes this issue.

To test
Select a theme
Select a preset
Save
Open theme editing page, theme and preset should be selected
Change theme
Return to original theme, preset should be selected