### PR TITLE
Prevent selects pushing button onto new line

### DIFF
--- a/frontend/src/modules/editor/themeEditor/less/editorTheming.less
+++ b/frontend/src/modules/editor/themeEditor/less/editorTheming.less
@@ -45,7 +45,7 @@
       padding-right: 15px;
       display: inline-block;
       select {
-        min-width: 150px;
+        width: 180px;
       }
     }
     .edit.btn.secondary {

--- a/frontend/src/modules/editor/themeEditor/less/editorTheming.less
+++ b/frontend/src/modules/editor/themeEditor/less/editorTheming.less
@@ -45,6 +45,12 @@
       padding-right: 15px;
       display: inline-block;
       select {
+        min-width: 150px;
+      }
+    }
+
+    &.show-preset-select {
+      select {
         width: 180px;
       }
     }

--- a/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
+++ b/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
@@ -62,12 +62,14 @@ define(function(require) {
       var selectedTheme = this.getSelectedTheme();
 
       if (!this.themeIsEditable(selectedTheme)) {
+        this.$('.theme-selector').removeClass('show-preset-select');
         this.$('.empty-message').show();
         this.$('.editable-theme').hide();
         $('.editor-theming-sidebar-reset').hide();
         return;
       }
 
+      this.$('.theme-selector').addClass('show-preset-select');
       this.$('.empty-message').hide();
       this.$('.editable-theme').show();
       $('.editor-theming-sidebar-reset').show();


### PR DESCRIPTION
Fixes #2361 

Sets the size of the selects so that they don't push the button onto a new line and so that the size doesn't change and cause the button to jump around when selecting different themes.