### PR TITLE
Improve upgrade functionality and bump default framework version

### DIFF
--- a/lib/installHelpers.js
+++ b/lib/installHelpers.js
@@ -253,7 +253,7 @@ function getInstalledFrameworkVersion(callback) {
 }
 
 function getLatestFrameworkVersion(installedVersion, callback) {
-  let versionLimit = pkg.framework;
+  let versionLimit;
   if (typeof installedVersion === 'function') {
     callback = installedVersion;
   } else {

--- a/lib/installHelpers.js
+++ b/lib/installHelpers.js
@@ -252,8 +252,14 @@ function getInstalledFrameworkVersion(callback) {
   });
 }
 
-function getLatestFrameworkVersion(callback) {
-  checkLatestAdaptRepoVersion('adapt_framework', pkg.framework, callback);
+function getLatestFrameworkVersion(installedVersion, callback) {
+  let versionLimit = pkg.framework;
+  if (typeof installedVersion === 'function') {
+    callback = installedVersion;
+  } else {
+    versionLimit = semver.major(installedVersion).toString();
+  }
+  checkLatestAdaptRepoVersion('adapt_framework', versionLimit, callback);
 }
 
 function getInstalledVersions(callback) {
@@ -268,20 +274,20 @@ function getInstalledVersions(callback) {
   });
 }
 
-function getLatestVersions(callback) {
+function getLatestVersions(installedVersions, callback) {
   async.parallel([
     exports.getLatestServerVersion,
-    exports.getLatestFrameworkVersion
+    async.apply(exports.getLatestFrameworkVersion, installedVersions.adapt_framework)
   ], function(error, results) {
-    callback(error, {
-      adapt_authoring: results[0],
-      adapt_framework: results[1]
-    });
+    callback(error, [
+      installedVersions,
+      { adapt_authoring: results[0], adapt_framework: results[1] }
+    ]);
   });
 }
 
 function getUpdateData(callback) {
-  async.parallel([
+  async.waterfall([
     exports.getInstalledVersions,
     exports.getLatestVersions
   ], function(error, results) {

--- a/lib/installHelpers.js
+++ b/lib/installHelpers.js
@@ -42,8 +42,8 @@ var inputHelpers = {
     readline.moveCursor(process.stdout, 0, -1);
     return v;
   },
-  isFalsyString: function(v) {
-    if (typeof v !== 'string') return false;
+  isFalsy: function(v) {
+    if (typeof v !== 'string') return !v;
     switch (v.trim()) {
       case '':
       case 'N':

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "type": "git",
     "url": "https://github.com/adaptlearning/adapt_authoring.git"
   },
-  "framework": "4",
   "main": "index",
   "engines": {
     "node": "10 || 12"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/adaptlearning/adapt_authoring.git"
   },
-  "framework": "2",
+  "framework": "4",
   "main": "index",
   "engines": {
     "node": "10 || 12"

--- a/upgrade.js
+++ b/upgrade.js
@@ -142,7 +142,7 @@ function checkForUpdates(callback) {
 function doUpdate(data) {
   async.series([
     function upgradeAuthoring(cb) {
-      if (installHelpers.inputHelpers.isFalsyString(data.adapt_authoring)) {
+      if (installHelpers.inputHelpers.isFalsy(data.adapt_authoring)) {
         return cb();
       }
       installHelpers.updateAuthoring({
@@ -159,7 +159,7 @@ function doUpdate(data) {
       });
     },
     function upgradeFramework(cb) {
-      if (installHelpers.inputHelpers.isFalsyString(data.adapt_framework)) {
+      if (installHelpers.inputHelpers.isFalsy(data.adapt_framework)) {
         return cb();
       }
       var dir = path.join(configuration.tempDir, configuration.getConfig('masterTenantID'), OutputConstants.Folders.Framework);


### PR DESCRIPTION
Resolves #2307.

For clarity,

#### Install script
* By default, the authoring tool will now install the latest tagged version of the framework
* Users may still specify any other revision manually

#### Upgrade script
* With an automatic `node upgrade`, the major range of the currently installed framework will be used to determine which version to upgrade to
* Again, users may still specify any other revision manually