### PR TITLE
Catch stream error

### DIFF
--- a/plugins/output/adapt/outputHelpers.js
+++ b/plugins/output/adapt/outputHelpers.js
@@ -137,6 +137,7 @@ function importAsset(fileMetadata, metadata, assetImported) {
     var hash = crypto.createHash('sha1');
     var rs = fs.createReadStream(fileMetadata.path);
 
+    rs.on('error', error => logger.log('error', error));
     rs.on('data', function onReadData(pData) {
       hash.update(pData, 'utf8');
     });


### PR DESCRIPTION
Handles uncaught exception detailed in #2486.

The `EISDIR: illegal operation on a directory, read` message is now at least fed through to the frontend.



