### PR TITLE
Ensure process.domain is set

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -290,9 +290,17 @@ Origin.prototype.createServer = function (options, cb) {
       requestDomain.session = req.session;
       requestDomain.on('error', next);
       requestDomain.run(next);
+      req.domain = requestDomain;
     });
     server.use(auth.initialize());
     server.use(auth.session());
+    server.use((req, res, next) => {
+      if (!process.domain) {
+        // set process.domain again, fixes adaptlearning/adapt_authoring#2504
+        req.domain.enter();
+      }
+      next();
+    });
     server.use(express.static(path.join(require('./configuration').serverRoot, 'frontend', 'build')));
     server.use(express.static(path.join(require('./configuration').serverRoot, 'frontend', 'src', 'libraries')));
     if(!app.configuration.getConfig('isProduction')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3966,15 +3966,15 @@
       "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
     },
     "mongoose": {
-      "version": "5.8.13",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.13.tgz",
-      "integrity": "sha512-YUBykYbx8/PMR1N8xAxl81PU+JQuMx5pVp7eHelifUMazshQqIwvToUtIxlinEG3NYbbS9FTSzYBrbBLDfrADQ==",
+      "version": "5.9.18",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.18.tgz",
+      "integrity": "sha512-agZbIuQcN1gZ12BJn6KesA+bgsvoLVjCwhfPw88hggxX8O24SWK4EJwN35GEZKDej9AHUZKNAPgmdeXCVQxviA==",
       "requires": {
-        "bson": "~1.1.1",
+        "bson": "^1.1.4",
         "kareem": "2.3.1",
-        "mongodb": "3.4.1",
+        "mongodb": "3.5.8",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.6.0",
+        "mpath": "0.7.0",
         "mquery": "3.2.2",
         "ms": "2.1.2",
         "regexp-clone": "1.0.0",
@@ -3983,26 +3983,56 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "mongodb": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.1.tgz",
-          "integrity": "sha512-juqt5/Z42J4DcE7tG7UdVaTKmUC6zinF4yioPfpeOSNBieWSK6qCY+0tfGQcHLKrauWPDdMZVROHJOa8q2pWsA==",
+        "bl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+          "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
           "requires": {
-            "bson": "^1.1.1",
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "bson": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
+        },
+        "mongodb": {
+          "version": "3.5.8",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.8.tgz",
+          "integrity": "sha512-jz7mR58z66JKL8Px4ZY+FXbgB7d0a0hEGCT7kw8iye46/gsqPrOEpZOswwJ2BQlfzsrCLKdsF9UcaUfGVN2HrQ==",
+          "requires": {
+            "bl": "^2.2.0",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
             "require_optional": "^1.0.1",
             "safe-buffer": "^5.1.2",
             "saslprep": "^1.0.0"
           }
         },
         "mpath": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
-          "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+          "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mime": "^2.4.4",
     "moment": "^2.24.0",
     "mongodb-uri": "^0.9.7",
-    "mongoose": "^5.7.3",
+    "mongoose": "^5.9.18",
     "morgan": "^1.9.1",
     "multer": "^1.4.2",
     "needle": "^2.4.0",


### PR DESCRIPTION
Identified the cause of #2504 as the 3.5 line of [MongoDB driver for Node.js](https://github.com/mongodb/node-mongodb-native), which the updated mongoose module lists as its dependency.

Somewhere in the middleware, `process.domain` gets lost so this PR includes a workaround to ensure it is set again.

Known deprecation warning:
```console
(node:13256) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the async_context variant of MakeCallback or the AsyncResource class instead.
```