### PR TITLE
Remove build includes after build

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -266,9 +266,6 @@ OutputPlugin.prototype.sanitizeCourseJSON = function(mode, json, next) {
 
     async.waterfall([
       function(callback) {
-        if (mode === Constants.Modes.Export) {
-          return callback();
-        }
         self.generateIncludesForConfig(configJson, function(error, includes) {
           if (error) {
             return callback(error);
@@ -925,6 +922,18 @@ OutputPlugin.prototype.applyMenu = function(tenantId, courseId, jsonObject, dest
     return next(null, menuName);
   }
 };
+
+OutputPlugin.prototype.removeBuildIncludes = async (configPath, next) => {
+  try {
+    const config = await fs.readJson(configPath);
+    await fs.writeJson(configPath, config, { spaces: 2, replacer: (key, value) => {
+      if (key !== 'build') return value;
+    }});
+    next(null);
+  } catch (err) {
+    next(err);
+  }
+}
 
 /**
  * extending plugins must implement this

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -224,6 +224,10 @@ function publishCourse(courseId, mode, request, response, next) {
       });
     },
     function(callback) {
+      const configPath = path.join(BUILD_FOLDER, Constants.Folders.Course, Constants.CourseCollections.config.filename);
+      self.removeBuildIncludes(configPath, err => callback(err));
+    },
+    function(callback) {
       if (mode === Constants.Modes.Preview) { // No download required -- skip this step
         return callback();
       }


### PR DESCRIPTION
As a side effect of #1586 & #1664, exports attempt to build with _all_ plugins bundled.

This PR ensures that build includes are always generated so that the grunt process uses the plugins relevant to the course. The build object is then removed from the config JSON after the build has completed.

Resolves #2510.