### PR TITLE
Fix paste zones

### DIFF
--- a/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
@@ -48,7 +48,7 @@ define(function(require){
         var events = {};
         events['editorView:moveBlock:' + id] = this.render;
         events['editorView:deleteArticle:' + id] = this.deletePageArticle;
-        events['editorView:pasted:' + id] = this.onPaste;
+        events['editorView:pasted:' + id] = this.render;
         this.listenTo(Origin, events);
       }
 
@@ -282,20 +282,6 @@ define(function(require){
         duration = 0;
       }
       this.$('.article-content').velocity(shouldCollapse ? 'slideUp' : 'slideDown', duration);
-    },
-
-    onPaste: function(data) {
-      (new BlockModel({ _id: data._id })).fetch({
-        success: _.bind(function(model) {
-          this.addBlockView(model);
-        }, this),
-        error: function(data) {
-          Origin.Notify.alert({
-            type: 'error',
-            text: 'app.errorfetchingdata'
-          });
-        }
-      });
     }
 
   }, {

--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -27,7 +27,7 @@ define(function(require){
         'pageView:itemAnimated': this.evaluateChildStatus
       };
       originEvents['editorView:moveArticle:' + id] = this.render;
-      originEvents['editorView:pasted:' + id] = this.onPaste;
+      originEvents['editorView:pasted:' + id] = this.render;
       this.listenTo(Origin, originEvents);
 
       Origin.options.addItems([
@@ -157,20 +157,6 @@ define(function(require){
         'contextMenu:page-min:copyID': this.onCopyID
       });
       Origin.trigger('contextMenu:open', fakeView, event);
-    },
-
-    onPaste: function(data) {
-      (new ArticleModel({ _id: data._id })).fetch({
-        success: _.bind(function(model) {
-          this.addArticleView(model);
-        }, this),
-        error: function(data) {
-          Origin.Notify.alert({
-            type: 'error',
-            text: 'app.errorfetchingdata'
-          });
-        }
-      });
     },
 
     onCutArticle: function(view) {

--- a/frontend/src/modules/editor/contentObject/views/editorPageView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageView.js
@@ -109,7 +109,7 @@ define(function(require){
         $.scrollTo(newArticleView.$el, 200);
       }
       // Increment the 'sortOrder' property
-      articleModel.set('_pasteZoneSortOrder', sortOrder++);
+      articleModel.set('_pasteZoneSortOrder', sortOrder + 1);
       // Post-article paste zone - sort order of placeholder will be one greater
       this.$('.page-articles').append(new EditorPasteZoneView({ model: articleModel }).$el);
       return newArticleView;


### PR DESCRIPTION
Reverts to re-rendering on paste to refresh the paste zones. It's slightly irritating to lose your place in the editor but better than articles being copied to wrong positions. Dragging an article already causes a re-render.

Resolves #1892.