### PR TITLE
Reintroduce fixed Mongoose dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4115,15 +4115,15 @@
       "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
     },
     "mongoose": {
-      "version": "5.9.18",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.18.tgz",
-      "integrity": "sha512-agZbIuQcN1gZ12BJn6KesA+bgsvoLVjCwhfPw88hggxX8O24SWK4EJwN35GEZKDej9AHUZKNAPgmdeXCVQxviA==",
+      "version": "5.8.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.13.tgz",
+      "integrity": "sha512-YUBykYbx8/PMR1N8xAxl81PU+JQuMx5pVp7eHelifUMazshQqIwvToUtIxlinEG3NYbbS9FTSzYBrbBLDfrADQ==",
       "requires": {
-        "bson": "^1.1.4",
+        "bson": "~1.1.1",
         "kareem": "2.3.1",
-        "mongodb": "3.5.8",
+        "mongodb": "3.4.1",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.7.0",
+        "mpath": "0.6.0",
         "mquery": "3.2.2",
         "ms": "2.1.2",
         "regexp-clone": "1.0.0",
@@ -4132,56 +4132,26 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "bl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-          "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "bson": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
-        },
         "mongodb": {
-          "version": "3.5.8",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.8.tgz",
-          "integrity": "sha512-jz7mR58z66JKL8Px4ZY+FXbgB7d0a0hEGCT7kw8iye46/gsqPrOEpZOswwJ2BQlfzsrCLKdsF9UcaUfGVN2HrQ==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.1.tgz",
+          "integrity": "sha512-juqt5/Z42J4DcE7tG7UdVaTKmUC6zinF4yioPfpeOSNBieWSK6qCY+0tfGQcHLKrauWPDdMZVROHJOa8q2pWsA==",
           "requires": {
-            "bl": "^2.2.0",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
+            "bson": "^1.1.1",
             "require_optional": "^1.0.1",
             "safe-buffer": "^5.1.2",
             "saslprep": "^1.0.0"
           }
         },
         "mpath": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
-          "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
+          "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mime": "^2.4.4",
     "moment": "^2.24.0",
     "mongodb-uri": "^0.9.7",
-    "mongoose": "^5.9.18",
+    "mongoose": "5.8.13",
     "morgan": "^1.9.1",
     "multer": "^1.4.2",
     "needle": "^2.4.0",


### PR DESCRIPTION
The PR reintroduces the `mongoose@5.8.13` dependency, which in turn pulls down the last version of `mongodb` that's known to work with the domain/session code in the authoring tool. Reference: #2504.

This does surface the following warnings in recent versions of Node.js:
```console
(node:20860) Warning: Accessing non-existent property 'count' of module exports inside circular dependency
(node:20860) Warning: Accessing non-existent property 'findOne' of module exports inside circular dependency
(node:20860) Warning: Accessing non-existent property 'remove' of module exports inside circular dependency
(node:20860) Warning: Accessing non-existent property 'updateOne' of module exports inside circular dependency
```
However, this seems like an adequate compromise having already done a sizeable chuck of debugging to try and ascertain why the domain goes missing in the middleware with later versions of `mongodb`.

This prevents the 'sticky session' problem detailed in #2540 if logging in to different user accounts using the same device (and browser and OS account).

Tested in Node 12 & 14.