### PR TITLE
Run grunt using npx

### DIFF
--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -185,9 +185,9 @@ function publishCourse(courseId, mode, request, response, next) {
         var generateSourcemap = outputJson.config._generateSourcemap;
         var buildMode = generateSourcemap === true ? 'dev' : 'prod';
 
-        logger.log('info', 'grunt server-build:' + buildMode + ' ' + args.join(' '));
+        logger.log('info', 'npx grunt server-build:' + buildMode + ' ' + args.join(' '));
 
-        child = exec('grunt server-build:' + buildMode + ' ' + args.join(' '), {cwd: path.join(FRAMEWORK_ROOT_FOLDER)},
+        child = exec('npx grunt server-build:' + buildMode + ' ' + args.join(' '), {cwd: path.join(FRAMEWORK_ROOT_FOLDER)},
           function(error, stdout, stderr) {
             if (error !== null) {
               logger.log('error', 'exec error: ' + error);


### PR DESCRIPTION
Fixes #2581

Using npx to run a local copy of grunt. Means we no longer need the global grunt CLI dependency.

### Note that this is a breaking change for the end-user, as `npx grunt build:prod` etc. will be needed to build the UI.