### PR TITLE
Add unsafe perm when running npm install

### DIFF
--- a/lib/installHelpers.js
+++ b/lib/installHelpers.js
@@ -648,7 +648,8 @@ function installDependencies(opts, callback) {
     if(error) {
       return callback(error);
     }
-    execCommand('npm install --loglevel error --production', { cwd: cwd }, function(error) {
+    execCommand('npm install --unsafe-perm=true --loglevel error --production', { cwd: cwd }, function(error) {
+    
       hideSpinner();
       if(error) {
         return callback(error);


### PR DESCRIPTION
Fixes #2566

This fix ensures that the framework install process is run with the same privileges as the main authoring process - i.e. if run as sudo, framework install will also use the sudo privileges.

Some quotes from Ollie's linked article to hopefully help in explanation:

> Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail. 

> If npm was invoked with root privileges, then it will change the uid to the user account or uid specified by the user config, which defaults to nobody. Set the unsafe-perm flag to run scripts with root privileges. 

> This issue that I’m facing is that the permissions my current user has are unable to create the symlinks that are being asked by the program. By setting unsafe-perm to true will force NPM to attempt to always run within the context of the running script.