### PR TITLE
Added check for existence of course

### DIFF
--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -106,6 +106,10 @@ function publishCourse(courseId, mode, request, response, next) {
         }
         isForceRebuild = request && request.query.force === 'true';
 
+        if (!fs.existsSync(path.normalize(BUILD_FOLDER + '/index.html'))) {
+          buildFlagExists = true;
+        }
+
         if (mode === Constants.Modes.Export || mode === Constants.Modes.Publish || buildFlagExists || isForceRebuild) {
           isRebuildRequired = true;
         }


### PR DESCRIPTION
## Proposed changes

Fixes #2696 by checking for the existence of the index.html file.

This was formerly [done here](https://github.com/adaptlearning/adapt_authoring/blame/0d1be218ad517317213deca780babafd0f1f31c0/plugins/output/adapt/publish.js#L162) but was removed in this [commit](https://github.com/adaptlearning/adapt_authoring/commit/5dd945abea2acef8ac5ab174f767bfe49dfecb07)

I changed the check to use `fs.existsSync()` rather than `fs.exists()` which has been deprecated.