### PR TITLE
Reverted to stable Mongoose version

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -270,7 +270,14 @@ Origin.prototype.createServer = function (options, cb) {
     server.use(session({
       key: 'connect.sid',
       secret: app.configuration.getConfig('sessionSecret'),
-      store: new MongoStore({ uri: db.conn.connectionUri }),
+      store: new MongoStore({ 
+        uri: db.conn.connectionUri,
+        connectionOptions: {
+          domainsEnabled: true,
+          useNewUrlParser: true,
+          useUnifiedTopology: true
+        }
+       }),
       resave: true,
       cookie: {
         signed: true,
@@ -284,9 +291,10 @@ Origin.prototype.createServer = function (options, cb) {
       requestDomain.add(res);
       requestDomain.session = req.session;
       requestDomain.on('error', next);
-      requestDomain.enter();
+      requestDomain.run(next);
+      // requestDomain.enter();
       // requestDomain.run(next());
-      next();
+      // next();
     });
     server.use(auth.initialize());
     server.use(auth.session());

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -494,7 +494,7 @@ exports = module.exports = {
       if(this.shouldIgnore(req.url)) {
         return next(); // route has been explicitly ignored somewhere
       }
-      const user = app.usermanager.getCurrentUser();
+      const user = app.usermanager.getCurrentUser() || JSON.parse(JSON.stringify(req.session.passport.user));
 
       if (!user || !user._id) {
         return res.status(403).json({ statusCode: STATUS.NOT_AUTHENTICATED });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapt_authoring",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adapt_authoring",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -19,7 +19,7 @@
         "bytes": "^3.1.2",
         "chalk": "^2.4.2",
         "compression": "^1.7.4",
-        "connect-mongodb-session": "^3.1.1",
+        "connect-mongodb-session": "^2.4.1",
         "consolidate": "^0.15.1",
         "cookie-parser": "^1.4.6",
         "email-templates": "^8.1.0",
@@ -54,7 +54,7 @@
         "mime": "^2.6.0",
         "moment": "^2.29.4",
         "mongodb-uri": "^0.9.7",
-        "mongoose": "^5.13.15",
+        "mongoose": "^5.8.13",
         "morgan": "^1.10.0",
         "multer": "^1.4.4",
         "needle": "^2.9.1",
@@ -76,7 +76,7 @@
         "mocha": "^6.2.3",
         "mocha-multi": "^1.1.6",
         "mocha-simple-html-reporter": "^1.1.0",
-        "mongodb": "^3.7.3",
+        "mongodb": "^4.10.0",
         "should": "^13.2.3",
         "supertest": "^4.0.2"
       },
@@ -99,6 +99,1387 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.328.0.tgz",
+      "integrity": "sha512-AePMM7xezk2SzrXqdKonVfed9zEgwHCQLIeYlgoP5e4lq+y0K2QlMobZW5i1A9qHfqGjJ93UjBoYASg2EsCPVA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.328.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.328.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.328.0.tgz",
+      "integrity": "sha512-IneVwc4j3bCXwCdNAALQ8VVrfFTFAb2f3FxerHv4DLx8OlMTvZiraDDJisfO+cXLl2WCJOJAzpAJTgrPA50LCg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.328.0.tgz",
+      "integrity": "sha512-2T6Snri7ovx9+q/iw/wZ1YHzz/SsxPuJOhgbJipCFW9f1IEPBIEKVZtywcKYzE1nYjyc6YanAqQMn6U2SPhW4A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.328.0.tgz",
+      "integrity": "sha512-Eedz24H7zLuTjJoCtNQEGOKbIlhibqyasFFwWsds6ds24hRF4fVrCKLwZWENZwawtJjjEdRESQe4dwpV5lWqtw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.328.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-sdk-sts": "3.326.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.328.0.tgz",
+      "integrity": "sha512-Q8rgwqkJznbCpNbK0pSgBujGaQ5S8Y6BpRVrc/F5I6+JB/xPD552eVfEnm8iSgzC5nmeN06RLjX8pXIIaZQ4og==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.328.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.328.0.tgz",
+      "integrity": "sha512-tOHzfWQUaQif1IciWs57MFM7bFc+693pnEhFCgT3wjzwjKGkq1QsNzfRlOp1QP4Glw6qV+kAAemEZj8mGth8Bg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.328.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.328.0.tgz",
+      "integrity": "sha512-/omjTxrC8Vv6OPAK+66KNnjVmMZWyEQnQp8e8Y+RZvsuVaeQNJT5UQKSqrYtmqTX2T+yqJY7eVpx5CXBCGjc2g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.328.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.328.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.328.0.tgz",
+      "integrity": "sha512-6lSfA3AcoqNt+OYJoBimWmPmqUYVCHkE0Y+4HFN7JaXCyUknsO9/71P5zo/pp8Q7/yxP/aRyzjael82G5thj0A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.328.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.328.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.328.0.tgz",
+      "integrity": "sha512-jSD+xxXLnB358fy2Mvbr5n8Ndzio/bvyMsarppwCp658//zbpu5ycKaMSbao47c3Xaiupgn6YOv5+SeQP+w7tA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.328.0",
+        "@aws-sdk/client-sso": "3.328.0",
+        "@aws-sdk/client-sts": "3.328.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.328.0",
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.328.0",
+        "@aws-sdk/credential-provider-node": "3.328.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.328.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
+      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
+      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
+      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
+      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
+      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.327.0.tgz",
+      "integrity": "sha512-LCG+oRIPc4XJ+DYqkSCgggavxWi4+hP3Rw40vHdHMNvJpCiUJMwVJ+dULEywEP/WZvr4AEkWiRrHmJVpSLeZ+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.327.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.326.0.tgz",
+      "integrity": "sha512-suOkuXxyAfOH0hznK63ZU10EoytKX5YPs9amO416VbgYFtuIeliCmntYfnl1jUvutp0fctGGpEGE9OnoYI+fhw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
+      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
+      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
+      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.327.0.tgz",
+      "integrity": "sha512-4rDSNY1xhlqfRcY97CQKcgs6AOe4ovtiRdCAjg2InnLOZHRVFoHhOIDxWNK2W1K2Pl65z4EGH6RXmB1t0srJHA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.328.0.tgz",
+      "integrity": "sha512-zxXdNfdSGi6w/1bopllxAYAufCGDNG2eLenR3Tjj/UVBGrvS4ME5NGInu6u4LirTdkSqYlZkqKMyfiZ6XxGfdQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.327.0.tgz",
+      "integrity": "sha512-bCWnw+uH3gI6yPxLi4a4WV71P1KlJU7Z4+iMBY1Gt4+ZsaPAJX9pAbuQcFhFH++4xTk/QaVMzSvD0uQ+u0B/NQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
+      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.328.0.tgz",
+      "integrity": "sha512-AWrRwa0RqSiz9CT3QKuMYuZsRXaeKCp8kMsx1CgrG5VUaag+NhDBBMYVbxgb0SyoqbsGC+wDUXtSCZctrE7Z3Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.328.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
+      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
+      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.327.0.tgz",
+      "integrity": "sha512-2+2jTfBzhXsfpOci61gzaoBUVdGhFWja7k5cLAfOaRROkK+m+Zv532+m3cCQZjBXJ6pJ952MbiAroRSjFq0/SQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.327.0.tgz",
+      "integrity": "sha512-y15NLGTAT2vaLzA8klJ6Bo8NGjVAa3/njqc4iCbta/3GqKpQU0zbvw3Y5aWyHp8BhV4DSUTp088jWjaoZlSqgw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.327.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1742,27 +3123,10 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-    },
-    "node_modules/@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dependencies": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "18.8.1",
@@ -1873,16 +3237,24 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
     "node_modules/archetype": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/archetype/-/archetype-0.13.0.tgz",
-      "integrity": "sha512-ts/rng/A4UQPw1ZuQWWZvR2T0q2S5+zQGBH0RPsSlmyIAsZuIGEm1rgRga2NJnHODBbW/jVWMZIWbtlEyrS7JQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/archetype/-/archetype-0.12.0.tgz",
+      "integrity": "sha512-kSuMmbcSC69EhmUtwM3pmE1dghtjqrsv9MhgTsShtHY5zOOzT5KVeLROwVYsBeq78ELPKstNw7LyTvcXgOC/cA==",
       "dependencies": {
         "lodash.clonedeep": "4.x",
         "lodash.set": "4.x",
-        "mpath": "0.8.x"
+        "mpath": "0.5.1"
       },
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/archetype/node_modules/mpath": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/archiver": {
@@ -2381,6 +3753,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3186,48 +4564,81 @@
       }
     },
     "node_modules/connect-mongodb-session": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/connect-mongodb-session/-/connect-mongodb-session-3.1.1.tgz",
-      "integrity": "sha512-HBfQW7lRLb64DopgxL4Pv8/iay4HcS1WU7YJfi7B8UbBPZGzVEHx67mx8xP5c2rWUMCQ4Xi/u4GUSC7e90Hhtw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/connect-mongodb-session/-/connect-mongodb-session-2.4.1.tgz",
+      "integrity": "sha512-pfTy1fAVYPhE7nFS4k/MoBm4C14PIQYz008TrZc/HIGeJhsZuxfYI5fsfC+neBZezFK28sBGHhao+9iFIjOggw==",
       "dependencies": {
-        "archetype": "0.13.x",
-        "mongodb": "4.x"
+        "archetype": "0.12.x",
+        "mongodb": "3.6.x"
       }
     },
-    "node_modules/connect-mongodb-session/node_modules/bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+    "node_modules/connect-mongodb-session/node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/connect-mongodb-session/node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/connect-mongodb-session/node_modules/mongodb": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.10.0.tgz",
-      "integrity": "sha512-My2QxLTw0Cc1O9gih0mz4mqo145Jq4rLAQx0Glk/Ha9iYBzYpt4I2QFNRIh35uNFNfe8KFQcdwY1/HKxXBkinw==",
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.12.tgz",
+      "integrity": "sha512-ErHpF4P4disEIQB8Nns2twIMVXcvmlwjpKqfVnyB/hhd/L5We48LfoBYjBjuUSiSqL6ffmcygPTgjvpy2LETRQ==",
       "dependencies": {
-        "bson": "^4.7.0",
-        "denque": "^2.1.0",
-        "mongodb-connection-string-url": "^2.5.3",
-        "socks": "^2.7.0"
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.0.3",
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=4"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.3"
+        "saslprep": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws4": {
+          "optional": true
+        },
+        "bson-ext": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "mongodb-extjson": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/connect-mongodb-session/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/connect-mongodb-session/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/consolidate": {
@@ -4458,6 +5869,22 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fd-slicer": {
@@ -6491,9 +7918,9 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -7185,31 +8612,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/migrate-mongo/node_modules/bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/migrate-mongo/node_modules/commander": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
       "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "engines": {
         "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/migrate-mongo/node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/migrate-mongo/node_modules/fs-extra": {
@@ -7234,23 +8642,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/migrate-mongo/node_modules/mongodb": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.10.0.tgz",
-      "integrity": "sha512-My2QxLTw0Cc1O9gih0mz4mqo145Jq4rLAQx0Glk/Ha9iYBzYpt4I2QFNRIh35uNFNfe8KFQcdwY1/HKxXBkinw==",
-      "dependencies": {
-        "bson": "^4.7.0",
-        "denque": "^2.1.0",
-        "mongodb-connection-string-url": "^2.5.3",
-        "socks": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=12.9.0"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.3"
       }
     },
     "node_modules/migrate-mongo/node_modules/universalify": {
@@ -7624,41 +9015,20 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12.9.0"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws4": {
-          "optional": true
-        },
-        "bson-ext": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
       }
     },
     "node_modules/mongodb-connection-string-url": {
@@ -7709,55 +9079,32 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/mongodb/node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+    "node_modules/mongodb/node_modules/bson": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
       "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/mongodb/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/mongodb/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "5.13.15",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
-      "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
+      "version": "5.8.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.13.tgz",
+      "integrity": "sha512-YUBykYbx8/PMR1N8xAxl81PU+JQuMx5pVp7eHelifUMazshQqIwvToUtIxlinEG3NYbbS9FTSzYBrbBLDfrADQ==",
       "dependencies": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
-        "kareem": "2.3.2",
-        "mongodb": "3.7.3",
+        "bson": "~1.1.1",
+        "kareem": "2.3.1",
+        "mongodb": "3.4.1",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.4",
-        "mquery": "3.2.5",
+        "mpath": "0.6.0",
+        "mquery": "3.2.2",
         "ms": "2.1.2",
-        "optional-require": "1.0.x",
         "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "13.5.2",
+        "safe-buffer": "5.1.2",
+        "sift": "7.0.1",
         "sliced": "1.0.1"
       },
       "engines": {
@@ -7776,32 +9123,21 @@
         "mongoose": "*"
       }
     },
-    "node_modules/mongoose/node_modules/optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.1.tgz",
+      "integrity": "sha512-juqt5/Z42J4DcE7tG7UdVaTKmUC6zinF4yioPfpeOSNBieWSK6qCY+0tfGQcHLKrauWPDdMZVROHJOa8q2pWsA==",
+      "dependencies": {
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2"
+      },
       "engines": {
         "node": ">=4"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.0"
       }
-    },
-    "node_modules/mongoose/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/moo": {
       "version": "0.5.2",
@@ -7848,17 +9184,17 @@
       }
     },
     "node_modules/mpath": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
+      "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw==",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+      "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
       "dependencies": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -9379,6 +10715,23 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dependencies": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/require_optional/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/require-at": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
@@ -9431,6 +10784,14 @@
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha512-qpFcKaXsq8+oRoLilkwyc7zHGF5i9Q2/25NIgLQQ/+VVv9rU4qvr6nXVAw1DsnXJyQkZsR4Ytfbtg5ehfcUssQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9813,9 +11174,9 @@
       }
     },
     "node_modules/sift": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -10432,6 +11793,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
     },
     "node_modules/superagent": {
       "version": "3.8.3",
@@ -11553,6 +12920,1335 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.328.0.tgz",
+      "integrity": "sha512-AePMM7xezk2SzrXqdKonVfed9zEgwHCQLIeYlgoP5e4lq+y0K2QlMobZW5i1A9qHfqGjJ93UjBoYASg2EsCPVA==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.328.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.328.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.328.0.tgz",
+      "integrity": "sha512-IneVwc4j3bCXwCdNAALQ8VVrfFTFAb2f3FxerHv4DLx8OlMTvZiraDDJisfO+cXLl2WCJOJAzpAJTgrPA50LCg==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.328.0.tgz",
+      "integrity": "sha512-2T6Snri7ovx9+q/iw/wZ1YHzz/SsxPuJOhgbJipCFW9f1IEPBIEKVZtywcKYzE1nYjyc6YanAqQMn6U2SPhW4A==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.328.0.tgz",
+      "integrity": "sha512-Eedz24H7zLuTjJoCtNQEGOKbIlhibqyasFFwWsds6ds24hRF4fVrCKLwZWENZwawtJjjEdRESQe4dwpV5lWqtw==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.328.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-sdk-sts": "3.326.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.328.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.328.0.tgz",
+      "integrity": "sha512-Q8rgwqkJznbCpNbK0pSgBujGaQ5S8Y6BpRVrc/F5I6+JB/xPD552eVfEnm8iSgzC5nmeN06RLjX8pXIIaZQ4og==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.328.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.328.0.tgz",
+      "integrity": "sha512-tOHzfWQUaQif1IciWs57MFM7bFc+693pnEhFCgT3wjzwjKGkq1QsNzfRlOp1QP4Glw6qV+kAAemEZj8mGth8Bg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.328.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.328.0.tgz",
+      "integrity": "sha512-/omjTxrC8Vv6OPAK+66KNnjVmMZWyEQnQp8e8Y+RZvsuVaeQNJT5UQKSqrYtmqTX2T+yqJY7eVpx5CXBCGjc2g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.328.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.328.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.328.0.tgz",
+      "integrity": "sha512-6lSfA3AcoqNt+OYJoBimWmPmqUYVCHkE0Y+4HFN7JaXCyUknsO9/71P5zo/pp8Q7/yxP/aRyzjael82G5thj0A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.328.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.328.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.328.0.tgz",
+      "integrity": "sha512-jSD+xxXLnB358fy2Mvbr5n8Ndzio/bvyMsarppwCp658//zbpu5ycKaMSbao47c3Xaiupgn6YOv5+SeQP+w7tA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.328.0",
+        "@aws-sdk/client-sso": "3.328.0",
+        "@aws-sdk/client-sts": "3.328.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.328.0",
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.328.0",
+        "@aws-sdk/credential-provider-node": "3.328.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.328.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
+      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
+      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
+      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
+      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
+      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.327.0.tgz",
+      "integrity": "sha512-LCG+oRIPc4XJ+DYqkSCgggavxWi4+hP3Rw40vHdHMNvJpCiUJMwVJ+dULEywEP/WZvr4AEkWiRrHmJVpSLeZ+Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.327.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.327.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.326.0.tgz",
+      "integrity": "sha512-suOkuXxyAfOH0hznK63ZU10EoytKX5YPs9amO416VbgYFtuIeliCmntYfnl1jUvutp0fctGGpEGE9OnoYI+fhw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
+      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
+      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
+      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.327.0.tgz",
+      "integrity": "sha512-4rDSNY1xhlqfRcY97CQKcgs6AOe4ovtiRdCAjg2InnLOZHRVFoHhOIDxWNK2W1K2Pl65z4EGH6RXmB1t0srJHA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.328.0.tgz",
+      "integrity": "sha512-zxXdNfdSGi6w/1bopllxAYAufCGDNG2eLenR3Tjj/UVBGrvS4ME5NGInu6u4LirTdkSqYlZkqKMyfiZ6XxGfdQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.327.0.tgz",
+      "integrity": "sha512-bCWnw+uH3gI6yPxLi4a4WV71P1KlJU7Z4+iMBY1Gt4+ZsaPAJX9pAbuQcFhFH++4xTk/QaVMzSvD0uQ+u0B/NQ==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
+      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.328.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.328.0.tgz",
+      "integrity": "sha512-AWrRwa0RqSiz9CT3QKuMYuZsRXaeKCp8kMsx1CgrG5VUaag+NhDBBMYVbxgb0SyoqbsGC+wDUXtSCZctrE7Z3Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.328.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
+      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
+      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.327.0.tgz",
+      "integrity": "sha512-2+2jTfBzhXsfpOci61gzaoBUVdGhFWja7k5cLAfOaRROkK+m+Zv532+m3cCQZjBXJ6pJ952MbiAroRSjFq0/SQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.327.0.tgz",
+      "integrity": "sha512-y15NLGTAT2vaLzA8klJ6Bo8NGjVAa3/njqc4iCbta/3GqKpQU0zbvw3Y5aWyHp8BhV4DSUTp088jWjaoZlSqgw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.327.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
       }
     },
     "@babel/code-frame": {
@@ -12691,27 +15387,10 @@
         "selderee": "^0.6.0"
       }
     },
-    "@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-    },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "18.8.1",
@@ -12794,13 +15473,20 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
     "archetype": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/archetype/-/archetype-0.13.0.tgz",
-      "integrity": "sha512-ts/rng/A4UQPw1ZuQWWZvR2T0q2S5+zQGBH0RPsSlmyIAsZuIGEm1rgRga2NJnHODBbW/jVWMZIWbtlEyrS7JQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/archetype/-/archetype-0.12.0.tgz",
+      "integrity": "sha512-kSuMmbcSC69EhmUtwM3pmE1dghtjqrsv9MhgTsShtHY5zOOzT5KVeLROwVYsBeq78ELPKstNw7LyTvcXgOC/cA==",
       "requires": {
         "lodash.clonedeep": "4.x",
         "lodash.set": "4.x",
-        "mpath": "0.8.x"
+        "mpath": "0.5.1"
+      },
+      "dependencies": {
+        "mpath": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+          "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
+        }
       }
     },
     "archiver": {
@@ -13189,6 +15875,12 @@
       "version": "1.8.14",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.14.tgz",
       "integrity": "sha512-8Rq058FD91q9Nwthyhw0la9fzpBz0iwZTrt51LWl+w+PnJgZk9J+5wp3nibsJcIUPglMYXr4NRBaR+TUj0OkBQ=="
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -13808,37 +16500,56 @@
       }
     },
     "connect-mongodb-session": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/connect-mongodb-session/-/connect-mongodb-session-3.1.1.tgz",
-      "integrity": "sha512-HBfQW7lRLb64DopgxL4Pv8/iay4HcS1WU7YJfi7B8UbBPZGzVEHx67mx8xP5c2rWUMCQ4Xi/u4GUSC7e90Hhtw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/connect-mongodb-session/-/connect-mongodb-session-2.4.1.tgz",
+      "integrity": "sha512-pfTy1fAVYPhE7nFS4k/MoBm4C14PIQYz008TrZc/HIGeJhsZuxfYI5fsfC+neBZezFK28sBGHhao+9iFIjOggw==",
       "requires": {
-        "archetype": "0.13.x",
-        "mongodb": "4.x"
+        "archetype": "0.12.x",
+        "mongodb": "3.6.x"
       },
       "dependencies": {
-        "bson": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-          "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
           "requires": {
-            "buffer": "^5.6.0"
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
           }
         },
-        "denque": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
-        },
         "mongodb": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.10.0.tgz",
-          "integrity": "sha512-My2QxLTw0Cc1O9gih0mz4mqo145Jq4rLAQx0Glk/Ha9iYBzYpt4I2QFNRIh35uNFNfe8KFQcdwY1/HKxXBkinw==",
+          "version": "3.6.12",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.12.tgz",
+          "integrity": "sha512-ErHpF4P4disEIQB8Nns2twIMVXcvmlwjpKqfVnyB/hhd/L5We48LfoBYjBjuUSiSqL6ffmcygPTgjvpy2LETRQ==",
           "requires": {
-            "bson": "^4.7.0",
-            "denque": "^2.1.0",
-            "mongodb-connection-string-url": "^2.5.3",
-            "saslprep": "^1.0.3",
-            "socks": "^2.7.0"
+            "bl": "^2.2.1",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "optional-require": "^1.0.3",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -14769,6 +17480,15 @@
       "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
       "requires": {
         "boolean": "^3.1.4"
+      }
+    },
+    "fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
       }
     },
     "fd-slicer": {
@@ -16243,9 +18963,9 @@
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ=="
     },
     "kareem": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -16814,23 +19534,10 @@
         "p-each-series": "^2.2.0"
       },
       "dependencies": {
-        "bson": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-          "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-          "requires": {
-            "buffer": "^5.6.0"
-          }
-        },
         "commander": {
           "version": "9.4.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
           "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
-        },
-        "denque": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
         },
         "fs-extra": {
           "version": "10.1.0",
@@ -16849,18 +19556,6 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          }
-        },
-        "mongodb": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.10.0.tgz",
-          "integrity": "sha512-My2QxLTw0Cc1O9gih0mz4mqo145Jq4rLAQx0Glk/Ha9iYBzYpt4I2QFNRIh35uNFNfe8KFQcdwY1/HKxXBkinw==",
-          "requires": {
-            "bson": "^4.7.0",
-            "denque": "^2.1.0",
-            "mongodb-connection-string-url": "^2.5.3",
-            "saslprep": "^1.0.3",
-            "socks": "^2.7.0"
           }
         },
         "universalify": {
@@ -17148,47 +19843,23 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.5.4",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.1"
       },
       "dependencies": {
-        "bl": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+        "bson": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+          "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
+            "buffer": "^5.6.0"
           }
         }
       }
@@ -17232,35 +19903,33 @@
       "integrity": "sha512-s6BdnqNoEYfViPJgkH85X5Nw5NpzxN8hoflKLweNa7vBxt2V7kaS06d74pAtqDxde8fn4r9h4dNdLiFGoNV0KA=="
     },
     "mongoose": {
-      "version": "5.13.15",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
-      "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
+      "version": "5.8.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.13.tgz",
+      "integrity": "sha512-YUBykYbx8/PMR1N8xAxl81PU+JQuMx5pVp7eHelifUMazshQqIwvToUtIxlinEG3NYbbS9FTSzYBrbBLDfrADQ==",
       "requires": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
-        "kareem": "2.3.2",
-        "mongodb": "3.7.3",
+        "bson": "~1.1.1",
+        "kareem": "2.3.1",
+        "mongodb": "3.4.1",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.4",
-        "mquery": "3.2.5",
+        "mpath": "0.6.0",
+        "mquery": "3.2.2",
         "ms": "2.1.2",
-        "optional-require": "1.0.x",
         "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "13.5.2",
+        "safe-buffer": "5.1.2",
+        "sift": "7.0.1",
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "optional-require": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-          "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        "mongodb": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.1.tgz",
+          "integrity": "sha512-juqt5/Z42J4DcE7tG7UdVaTKmUC6zinF4yioPfpeOSNBieWSK6qCY+0tfGQcHLKrauWPDdMZVROHJOa8q2pWsA==",
+          "requires": {
+            "bson": "^1.1.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
         }
       }
     },
@@ -17311,14 +19980,14 @@
       }
     },
     "mpath": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
+      "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
     },
     "mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+      "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -18483,6 +21152,22 @@
         }
       }
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "require-at": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
@@ -18516,6 +21201,11 @@
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
       }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha512-qpFcKaXsq8+oRoLilkwyc7zHGF5i9Q2/25NIgLQQ/+VVv9rU4qvr6nXVAw1DsnXJyQkZsR4Ytfbtg5ehfcUssQ=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -18838,9 +21528,9 @@
       }
     },
     "sift": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -19312,6 +22002,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
     },
     "superagent": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bytes": "^3.1.2",
     "chalk": "^2.4.2",
     "compression": "^1.7.4",
-    "connect-mongodb-session": "^3.1.1",
+    "connect-mongodb-session": "^2.4.1",
     "consolidate": "^0.15.1",
     "cookie-parser": "^1.4.6",
     "email-templates": "^8.1.0",
@@ -87,7 +87,7 @@
     "mocha": "^6.2.3",
     "mocha-multi": "^1.1.6",
     "mocha-simple-html-reporter": "^1.1.0",
-    "mongodb": "^3.7.3",
+    "mongodb": "^4.10.0",
     "should": "^13.2.3",
     "supertest": "^4.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mime": "^2.6.0",
     "moment": "^2.29.4",
     "mongodb-uri": "^0.9.7",
-    "mongoose": "^5.13.15",
+    "mongoose": "^5.8.13",
     "morgan": "^1.10.0",
     "multer": "^1.4.4",
     "needle": "^2.9.1",


### PR DESCRIPTION
Fixes #2697 by reintroducing former stable version of connect-mongodb-session, mongoose and mongodb, which have support for domainsEnabled property.