### PR TITLE
Fix: CKEditor stripping out needed HTML attributes (fixes #2738)

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -81,7 +81,7 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
-    ckEditorExtraAllowedContent: 'span(*)',
+    ckEditorExtraAllowedContent: 'blockquote div hr li ol pre ul span p aside dd dt dl figcaption figure menu a abbr b bdi bdo cite code data dfn kbd mark q rp rt ruby samp small span time var wbr strong sub sup u *(*)',
     maxFileUploadSize: '200MB',
     ckEditorEnterMode: 'ENTER_P'
   };


### PR DESCRIPTION
#2738 

Fixes 
- CKEditor stripping out needed HTML attributes (fixes #2738)
