### PR TITLE
Node version parity with FW

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "index",
   "engines": {
-    "node": "16 || 18"
+    "node": ">=22"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
Fixes #2847 

Updated AAT Node version to parity with FW. I've tested this locally with a fresh install and worked fine. Also managed to upgrade a more than 2 year old AAT and worked fine.

Only warning was this: ``(node:28020) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated.
 Please use `Array.isArray()` instead.``
 
@swashbuck happy to proceed with your suggested approach of Node version upgrade for both FW and AAT.
